### PR TITLE
Updating the readme to remove the email address and simplify the contributions text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,7 @@ A [Grunt](http://gruntjs.com/) task is used for builds. To prepare your code for
 
 # Contributing to the Kraken Suite
 
-### Bug Fixes
-
-If you find a bug you would like fixed. Open up a [ticket](https://github.com/PayPal/kraken-js/issues/new) with a detailed description of the bug and the expected behaviour. If you would like to fix the problem yourself please do the following steps.
+Bugs and new features should be submitted using [Github issues](https://github.com/PayPal/kraken-js/issues/new). Please include with a detailed description and the expected behaviour. If you would like to submit a change yourself do the following steps.
 
 1. Fork it.
 2. Create a branch (`git checkout -b fix-for-that-thing`)
@@ -204,10 +202,6 @@ If you find a bug you would like fixed. Open up a [ticket](https://github.com/Pa
 5. Open a [Pull Request](https://github.com/PayPal/kraken-js/pulls)
 
 Please keep your branch up to date by rebasing upstream changes from master.
-
-### New Functionality
-
-If you wish to add new functionality to the Kraken, please provide [the Kraken team](mailto:DL-PP-Kraken-Js@ebay.com) an example application that demonstrates deficiency in current design or desired additional behaviour. You may also submit a pull request with the steps above.
 
 
 ## FAQ


### PR DESCRIPTION
Communication over kraken should be kept out of email and instead in Github issues/comments.
