### PR TITLE
[Issue #7] Add support for graceful shutdowns.

### DIFF
--- a/config/webcore.json
+++ b/config/webcore.json
@@ -4,6 +4,8 @@
 
     "host": ["OPENSHIFT_NODEJS_IP", "VCAP_APP_HOST", "HOST", "IP"],
 
+    "shutdownTimeout": 30000,
+
     "globalAgent": {
         "maxSockets": 250
     },

--- a/index.js
+++ b/index.js
@@ -138,7 +138,8 @@ var kraken = {
             server = ssl ? https.createServer(ssl, app) : http.createServer(app);
             server.once('listening', resolve);
             server.once('error', reject);
-            server.listen(port, host);
+            var httpServer = server.listen(port, host);
+            app.set('kraken:server', httpServer);
 
             return deferred.promise;
         }

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ var kraken = {
         }
 
         function bind(app) {
-            var deferred, server, ssl;
+            var deferred, server, ssl, httpServer;
 
             if (port === undefined) {
                 port = that.port;
@@ -138,7 +138,7 @@ var kraken = {
             server = ssl ? https.createServer(ssl, app) : http.createServer(app);
             server.once('listening', resolve);
             server.once('error', reject);
-            var httpServer = server.listen(port, host);
+            httpServer = server.listen(port, host);
             app.set('kraken:server', httpServer);
 
             return deferred.promise;

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -164,6 +164,7 @@ var proto = {
         srcRoot = this._resolve(config.static.srcRoot);
         staticRoot = this._resolve(config.static.rootPath);
 
+        app.use(kraken.shutdown(app, this._config));
         app.use(express.favicon());
         app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
         app.use(express.static(staticRoot));

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -163,8 +163,9 @@ var proto = {
         config = this._config.get('middleware');
         srcRoot = this._resolve(config.static.srcRoot);
         staticRoot = this._resolve(config.static.rootPath);
+        errorPages = config.errorPages || {};
 
-        app.use(kraken.shutdown(app, this._config));
+        app.use(kraken.shutdown(app, this._config, errorPages['503']));
         app.use(express.favicon());
         app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
         app.use(express.static(staticRoot));
@@ -198,7 +199,6 @@ var proto = {
             delegate.requestAfterRoute(app);
         }
 
-        errorPages = config.errorPages || {};
         app.use(kraken.fileNotFound(errorPages['404']));
         app.use(kraken.serverError(errorPages['500']));
         app.use(kraken.errorHandler(config.errorHandler));

--- a/lib/middleware/shutdown.js
+++ b/lib/middleware/shutdown.js
@@ -23,7 +23,7 @@ module.exports = function (app, config, template) {
 
     var gracefulShutdown = function () {
         var server, timeout;
-        config.set('kraken:shuttingDown', true);
+        config.set('kraken:state', 'disconnecting');
 
         server = app.get('kraken:server');
         // switch to kraken.close once it's implemented
@@ -31,7 +31,7 @@ module.exports = function (app, config, template) {
             process.exit();
         });
 
-        timeout = config.get('shutdown_timeout') || 30 * 1000;
+        timeout = config.get('shutdownTimeout');
         setTimeout(function () {
             process.exit(1);
         }, timeout);
@@ -41,7 +41,7 @@ module.exports = function (app, config, template) {
     process.on('SIGINT', gracefulShutdown);
 
     return function (req, res, next) {
-        if (!config.get('kraken:shuttingDown')) {
+        if (config.get('kraken:state') !== 'disconnecting') {
             return next();
         }
         res.setHeader('Connection', 'close');

--- a/lib/middleware/shutdown.js
+++ b/lib/middleware/shutdown.js
@@ -19,37 +19,37 @@
 /***@@@ END LICENSE @@@***/
 'use strict';
 
-module.exports = function (app, settings, template) {
+module.exports = function (app, config, template) {
 
     var gracefulShutdown = function () {
-        settings.set('kraken:shuttingDown', true);
-        console.log("Received kill signal, shutting down gracefully.");
-        var server = app.get('kraken:server');
+        var server, timeout;
+        config.set('kraken:shuttingDown', true);
+
+        server = app.get('kraken:server');
         // switch to kraken.close once it's implemented
         server.close(function () {
-            console.log("Closed out remaining connections.");
             process.exit();
         });
 
+        timeout = config.get('shutdown_timeout') || 30 * 1000;
         setTimeout(function () {
-            console.error("Could not close connections in time, forcefully shutting down.");
             process.exit(1);
-        }, 30 * 1000);
+        }, timeout);
     };
 
-    process.on("SIGTERM", gracefulShutdown);
-    process.on("SIGINT", gracefulShutdown);
+    process.on('SIGTERM', gracefulShutdown);
+    process.on('SIGINT', gracefulShutdown);
 
     return function (req, res, next) {
-        if (!settings.get('kraken:shuttingDown')) {
+        if (!config.get('kraken:shuttingDown')) {
             return next();
         }
-        res.setHeader("Connection", "close");
+        res.setHeader('Connection', 'close');
         if (template && !req.xhr) {
             res.status(503);
             res.render(template);
         } else {
-            res.send(503, "Server is in the process of shutting down.");
+            res.send(503, 'Server is in the process of shutting down.');
         }
     };
 

--- a/lib/middleware/shutdown.js
+++ b/lib/middleware/shutdown.js
@@ -19,28 +19,33 @@
 /***@@@ END LICENSE @@@***/
 'use strict';
 
-var error = require('./error');
+module.exports = function (app, settings) {
 
+    var gracefulShutdown = function () {
+        settings.set('kraken:shuttingDown', true);
+        console.log("Received kill signal, shutting down gracefully.");
+        var server = app.get('kraken:server');
+        // switch to kraken.close once it's implemented
+        server.close(function () {
+            console.log("Closed out remaining connections.");
+            process.exit();
+        });
 
-exports = module.exports = {
+        setTimeout(function () {
+            console.error("Could not close connections in time, forcefully shutting down.");
+            process.exit(1);
+        }, 30 * 1000);
+    };
 
-    logger: require('./logger'),
+    process.on("SIGTERM", gracefulShutdown);
+    process.on("SIGINT", gracefulShutdown);
 
-    session: require('./session'),
-
-    appsec: require('lusca'),
-
-    // TODO: Add multipart support
-    //multipart: require('./multipart'),
-
-    shutdown: require('./shutdown'),
-
-    compiler: require('./compiler'),
-
-    fileNotFound: error.fileNotFound,
-
-    serverError: error.serverError,
-
-    errorHandler: error.defaultHandler
+    return function (req, res, next) {
+        if (!settings.get('kraken:shuttingDown')) {
+            return next();
+        }
+        res.setHeader("Connection", "close");
+        res.send(502, "Server is in the process of restarting.");
+    };
 
 };

--- a/lib/middleware/shutdown.js
+++ b/lib/middleware/shutdown.js
@@ -49,7 +49,7 @@ module.exports = function (app, settings, template) {
             res.status(503);
             res.render(template);
         } else {
-            res.send(503, "Server is in the process of restarting.");
+            res.send(503, "Server is in the process of shutting down.");
         }
     };
 

--- a/lib/middleware/shutdown.js
+++ b/lib/middleware/shutdown.js
@@ -19,7 +19,7 @@
 /***@@@ END LICENSE @@@***/
 'use strict';
 
-module.exports = function (app, settings) {
+module.exports = function (app, settings, template) {
 
     var gracefulShutdown = function () {
         settings.set('kraken:shuttingDown', true);
@@ -45,7 +45,12 @@ module.exports = function (app, settings) {
             return next();
         }
         res.setHeader("Connection", "close");
-        res.send(502, "Server is in the process of restarting.");
+        if (template && !req.xhr) {
+            res.status(503);
+            res.render(template);
+        } else {
+            res.send(503, "Server is in the process of restarting.");
+        }
     };
 
 };


### PR DESCRIPTION
With this change hitting Control+C or sending kill -{2,15} <pid> (SIGINT or SIGTERM) will cause the server to shutdown gracefully draining any connections. Clients which connect will see this message:

> Server is in the process of restarting.

If the connections are drained successfully prior to the timeout, stdout will display:

> Received kill signal, shutting down gracefully.
> Closed out remaining connections.

and the exit code will be 0. Otherwise you'll see:

> Received kill signal, shutting down gracefully.
> Could not close connections in time, forcefully shutting down.

and the exit code will be 1. The timeout is hardcoded at 30s, perhaps this should be configurable.
