### PR TITLE
add config session able or disable

### DIFF
--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -180,7 +180,11 @@ var proto = {
         app.use(express.multipart(config.bodyParser || config.multipart || { limit: 2097152 })); // default to 2mb limit
 
         app.use(express.cookieParser(config.session.secret));
-        app.use(kraken.session(config.session));
+        
+        if (config.session.module) {
+            app.use(kraken.session(config.session));
+        }
+        
         app.use(kraken.appsec(config.appsec));
 
         if (typeof delegate.requestBeforeRoute === 'function') {


### PR DESCRIPTION
sometimes we not need use session store in our web server, e.g: not browser request, like mobile app request , it often not set cookie session in request,so one request,server will generate one session in memory, it watse server  resources.
