### PR TITLE
Configurable favicon in config/middleware.json

### DIFF
--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -162,7 +162,7 @@ var proto = {
         srcRoot = this._resolve(config.static.srcRoot);
         staticRoot = this._resolve(config.static.rootPath);
 
-        if (config.favicon !== '') {
+        if (config.favicon !== false) {
             app.use(express.favicon(config.favicon));
         }
         app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -162,7 +162,7 @@ var proto = {
         srcRoot = this._resolve(config.static.srcRoot);
         staticRoot = this._resolve(config.static.rootPath);
 
-        app.use(express.favicon());
+        if (config.favicon !== '') app.use(express.favicon(config.favicon));
         app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
         app.use(express.static(staticRoot));
         app.use(kraken.logger(config.logger));

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -162,7 +162,9 @@ var proto = {
         srcRoot = this._resolve(config.static.srcRoot);
         staticRoot = this._resolve(config.static.rootPath);
 
-        if (config.favicon !== '') app.use(express.favicon(config.favicon));
+        if (config.favicon !== '') {
+            app.use(express.favicon(config.favicon));
+        }
         app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
         app.use(express.static(staticRoot));
         app.use(kraken.logger(config.logger));


### PR DESCRIPTION
Setting `favicon:""` disables express.favicon() so requests can be served as
static files, otherwise the value is passed on as favicon file path argument.
