### PR TITLE
Fixed typo in localization example code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,7 +464,7 @@ res.render('index',model);</pre>
     <p>
         <code>locales/<strong>US/en/</strong>index.properties</code>
         <br> to hold <br>
-        <code>index.greeting=Hello{name}!</code>
+        <code>index.greeting=Hello {name}!</code>
 
         <br>and<br>
 


### PR DESCRIPTION
Missing space between greeting and `name` has been restored.
