### PR TITLE
Plugin architecture for middleware

### DIFF
--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -29,6 +29,23 @@ var Q = require('q'),
     config = util.configutil;
 
 
+var slots = {
+    'shutdown': kraken.shutdown,
+    'favicon': express.favicon,
+    'compiler': kraken.compiler,
+    'static': express.static,
+    'logger': kraken.logger,
+    'json': express.json,
+    'urlencoded': express.urlencoded,
+    'multipart': express.multipart,
+    'cookieParser': express.cookieParser,
+    'session': kraken.session,
+    'appsec': kraken.appsec,
+    'fileNotFound': kraken.fileNotFound,
+    'serverError': kraken.serverError,
+    'errorHandler': kraken.errorHandler
+};
+
 var proto = {
 
     init: function (callback) {
@@ -163,22 +180,6 @@ var proto = {
         staticRoot = this._resolve(config.static.rootPath);
         errorPages = config.errorPages || {};
 
-        var slots = {
-            'shutdown':     kraken.shutdown,
-            'favicon':      express.favicon,
-            'compiler':     kraken.compiler,
-            'static':       express.static,
-            'logger':       kraken.logger,
-            'json':         express.json,
-            'urlencoded':   express.urlencoded,
-            'multipart':    express.multipart,
-            'cookieParser': express.cookieParser,
-            'session':      kraken.session,
-            'appsec':       kraken.appsec,
-            'fileNotFound': kraken.fileNotFound,
-            'serverError':  kraken.serverError,
-            'errorHandler': kraken.errorHandler
-        };
         var slotNames = Object.keys(slots);
 
         if (typeof delegate.reviewMiddleware === 'function') {

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -163,11 +163,44 @@ var proto = {
         staticRoot = this._resolve(config.static.rootPath);
         errorPages = config.errorPages || {};
 
-        app.use(kraken.shutdown(app, this._config, errorPages['503']));
-        app.use(express.favicon());
-        app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
-        app.use(express.static(staticRoot));
-        app.use(kraken.logger(config.logger));
+        var slots = {
+            'shutdown':     kraken.shutdown,
+            'favicon':      express.favicon,
+            'compiler':     kraken.compiler,
+            'static':       express.static,
+            'logger':       kraken.logger,
+            'json':         express.json,
+            'urlencoded':   express.urlencoded,
+            'multipart':    express.multipart,
+            'cookieParser': express.cookieParser,
+            'session':      kraken.session,
+            'appsec':       kraken.appsec,
+            'fileNotFound': kraken.fileNotFound,
+            'serverError':  kraken.serverError,
+            'errorHandler': kraken.errorHandler
+        };
+        var slotNames = Object.keys(slots);
+
+        if (typeof delegate.reviewMiddleware === 'function') {
+            delegate.reviewMiddleware(slots);
+        }
+
+        function slotDisabled()
+        {
+            // The value returned here will come back as the
+            // delegate argument to the function create() below
+            // which needs to handle it gracefully.
+            return false;
+        }
+        slotNames.forEach(function(name) {
+            if (!slots[name]) { slots[name] = slotDisabled; }
+        });
+        
+        app.use(slots.shutdown(app, this._config, errorPages['503']));
+        app.use(slots.favicon());
+        app.use(slots.compiler(srcRoot, staticRoot, this._config, this._i18n));
+        app.use(slots.static(staticRoot));
+        app.use(slots.logger(config.logger));
 
         if (typeof delegate.requestStart === 'function') {
             delegate.requestStart(app);
@@ -175,15 +208,15 @@ var proto = {
 
         config.bodyParser && console.warn('The `middleware:bodyParser` configuration will not be honored in future versions. Use `middleware:json`, `middleware:urlencoded`, and `middleware.multipart`.');
 
-        app.use(express.json(config.bodyParser || config.json));
-        app.use(express.urlencoded(config.bodyParser || config.urlencoded));
+        app.use(slots.json(config.bodyParser || config.json));
+        app.use(slots.urlencoded(config.bodyParser || config.urlencoded));
 
         console.warn('Multipart body parsing will be disabled by default in future versions. To enable, use `middleware:multipart` configuration.');
-        app.use(express.multipart(config.bodyParser || config.multipart || { limit: 2097152 })); // default to 2mb limit
+        app.use(slots.multipart(config.bodyParser || config.multipart || { limit: 2097152 })); // default to 2mb limit
 
-        app.use(express.cookieParser(config.session.secret));
-        app.use(kraken.session(config.session));
-        app.use(kraken.appsec(config.appsec));
+        app.use(slots.cookieParser(config.session.secret));
+        app.use(slots.session(config.session));
+        app.use(slots.appsec(config.appsec));
 
         if (typeof delegate.requestBeforeRoute === 'function') {
             delegate.requestBeforeRoute(app);
@@ -197,9 +230,9 @@ var proto = {
             delegate.requestAfterRoute(app);
         }
 
-        app.use(kraken.fileNotFound(errorPages['404']));
-        app.use(kraken.serverError(errorPages['500']));
-        app.use(kraken.errorHandler(config.errorHandler));
+        app.use(slots.fileNotFound(errorPages['404']));
+        app.use(slots.serverError(errorPages['500']));
+        app.use(slots.errorHandler(config.errorHandler));
     },
 
     _resolve: function (path) {
@@ -209,6 +242,8 @@ var proto = {
 
 
 function create(delegate, resolver, callback) {
+    if (false === delegate) { return; }
+
     var app, appcore;
 
     if (isExpress(delegate)) {

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -192,7 +192,7 @@ var proto = {
             // which needs to handle it gracefully.
             return false;
         }
-        slotNames.forEach(function(name) {
+        slotNames.forEach(function (name) {
             if (!slots[name]) { slots[name] = slotDisabled; }
         });
         


### PR DESCRIPTION
Similar to the existing `requestStart`, `requestBeforeRoute`, etc.
give the application a chance to disable/replace
each middleware that Kraken uses by implementing
`reviewMiddleware(slots)`

For instance, to remove the favicon middleware
put this in the application's index.js:

```
app.reviewMiddleware = function reviewMiddleware(middleware) {
    delete middleware.favicon;
};
```

This covers my use case in a more general way
than #47 ("Configurable favicon in config/middleware.json")
and also covers #41 ("add config session able or disable")
so I propose it as a fix for #50 ("Plugin Architecture for Middleware").
