### PR TITLE
Provide a way to opt out of view rendering

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,8 @@ module.exports = function (grunt) {
             }
         },
         clean: {
-            'tmp': '/tmp/kraken*'
+            'tmp': '/tmp/kraken*',
+            'build': 'test/fixtures/.build'
         }
     });
 
@@ -45,6 +46,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-mocha-test');
     grunt.loadNpmTasks('grunt-contrib-clean');
 
-    grunt.registerTask('test', ['jshint', 'mochaTest', 'clean:tmp']);
+    grunt.registerTask('test', ['jshint', 'mochaTest', 'clean']);
 
 };

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -103,7 +103,7 @@ var proto = {
         app = this._app;
         config = this._config;
         engines = config.get('view engines');
-        if (!engines || !engines.length) { return; }
+        if (!engines || !Object.keys(engines).length) { return; }
 
         // If i18n is enabled (config is available), set its cache
         // to the view cache value, and disable the view cache.

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -73,7 +73,7 @@ var proto = {
                 tls.CLIENT_RENEG_WINDOW = settings.clientRenegotiationWindow || tls.CLIENT_RENEG_WINDOW;
             }
 
-            self._views();
+            app.get('view engine') && self._views();
             self._middleware();
             callback();
         }
@@ -91,7 +91,7 @@ var proto = {
 
 
     _views: function () {
-        var app, config, engines, i18n, cache, module;
+        var app, config, i18n, cache, engines, module;
 
         /**
          * XXXXX ACHTUNG! ALERT! ALERT! PELIGRO! XXXXX
@@ -102,8 +102,6 @@ var proto = {
 
         app = this._app;
         config = this._config;
-        engines = config.get('view engines');
-        if (!engines || !Object.keys(engines).length) { return; }
 
         // If i18n is enabled (config is available), set its cache
         // to the view cache value, and disable the view cache.
@@ -121,7 +119,9 @@ var proto = {
             }
         }
 
+
         // Register each rendering engine
+        engines = config.get('view engines');
         Object.keys(engines).forEach(function (ext) {
             var meta, engine, renderer;
 

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -91,7 +91,7 @@ var proto = {
 
 
     _views: function () {
-        var app, config, i18n, cache, engines, module;
+        var app, config, engines, i18n, cache, module;
 
         /**
          * XXXXX ACHTUNG! ALERT! ALERT! PELIGRO! XXXXX
@@ -102,6 +102,8 @@ var proto = {
 
         app = this._app;
         config = this._config;
+        engines = config.get('view engines');
+        if (!engines || !engines.length) { return; }
 
         // If i18n is enabled (config is available), set its cache
         // to the view cache value, and disable the view cache.
@@ -119,9 +121,7 @@ var proto = {
             }
         }
 
-
         // Register each rendering engine
-        engines = config.get('view engines');
         Object.keys(engines).forEach(function (ext) {
             var meta, engine, renderer;
 

--- a/test/fixtures/controllers/controller.js
+++ b/test/fixtures/controllers/controller.js
@@ -33,4 +33,15 @@ module.exports = function (app) {
         throw new Error('uh oh');
     });
 
+
+    app.get('/json', function (req, res) {
+        res.json({ call: 'me maybe' });
+    });
+
+
+    app.get('/plain', function (req, res) {
+        res.set('Content-Type', 'text/plain');
+        res.send(200, 'ok');
+    });
+
 };

--- a/test/views.js
+++ b/test/views.js
@@ -230,6 +230,23 @@ describe('view', function () {
                     .expect('Content-Type', /plain/)
                     .expect('ok', next);
             }
+        },
+
+        'should fail when attempting to use a nonexistent view engine': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('view engines', null);
+                    config.set('express:view engine', null);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/')
+                    .expect(500)
+                    .expect('Content-Type', /plain/)
+                    .expect(/^Error: No default engine was specified and no extension was provided/, next);
+            }
         }
     };
 

--- a/test/views.js
+++ b/test/views.js
@@ -196,6 +196,40 @@ describe('view', function () {
                     .expect('Content-Type', /html/)
                     .expect(SERVER_ERROR, next);
             }
+        },
+
+        'should not require a view engine for json responses': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('view engines', null);
+                    config.set('express:view engine', null);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/json')
+                    .expect(200)
+                    .expect('Content-Type', /json/)
+                    .expect('{\n  "call": "me maybe"\n}', next);
+            }
+        },
+
+        'should not require a view engine for plain text responses': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('view engines', null);
+                    config.set('express:view engine', null);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/plain')
+                    .expect(200)
+                    .expect('Content-Type', /plain/)
+                    .expect('ok', next);
+            }
         }
     };
 


### PR DESCRIPTION
With this PR developers can opt out of all view rendering via configuration. By setting the following, no view engines will be required to start/run kraken-js applications.

`application.json`

``` json
{
  "view engines": null,
  "express": {
    "view engine": null
  }
}
```

Fixes issue #57.
