### PR TITLE
Better Error Handling in Example

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,9 @@ app.requestBeforeRoute = function (server) { };
 app.requestAfterRoute = function requestAfterRoute(server) { };
 
 kraken.create(app).listen(function (err) {
-    if (err) { console.error(err); }
+    if (err) {
+        console.error(err.stack);
+    }
 });</pre>
     <p>
         As you can see, the entry point simply provides hooks for configuration, and request-specific


### PR DESCRIPTION
Moved from `console.error(err)` to `console.error(err.stack)` which will produce output more inline with what one would expect in this scenario (a full stack trace).

Also I hate single line ifs that _also_ have braces, so I added newlines. If that's the standard though i can remove the whitespace.
