### PR TITLE
Use compress middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ To retrieve it in your application, you can do so during the [configuration step
       - **srcRoot** - Where the compiler should look for files. *Default: `"path:./public"`*
       - **rootPath** - Where the compiler should put compiled files. *Default: `"path:./.build"`*
 
+  - **express**
+      - **compress** - Compress response data with gzip / deflate. *Default: `false`*
 
 
 ## Customization

--- a/config/middleware.json
+++ b/config/middleware.json
@@ -25,6 +25,10 @@
             "xframe": "SAMEORIGIN",
             "p3p": "NOI DSP CUR ADMa OUR IND NAV STA PUR",
             "csp": false
+        },
+        
+        "express": {
+          "compress": true
         }
 
     },

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -165,6 +165,12 @@ var proto = {
 
         app.use(kraken.shutdown(app, this._config, errorPages['503']));
         app.use(express.favicon());
+        
+        // Configure express to use compression
+        if (config.express.compress) {
+            app.use(express.compress());
+        }
+        
         app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
         app.use(express.static(staticRoot));
         app.use(kraken.logger(config.logger));

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -167,7 +167,7 @@ var proto = {
         app.use(express.favicon());
         
         // Configure express to use compression
-        if (config.express.compress) {
+        if (config.express !== undefined && config.express.compress) {
             app.use(express.compress());
         }
         


### PR DESCRIPTION
Add the possibility to use express.compress() to compress response data with gzip / deflate. Can compress static content like CSS and dynamic content.
