### PR TITLE
Look for favicon in .build or public

### DIFF
--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -26,7 +26,8 @@ var Q = require('q'),
     kraken = require('./middleware'),
     util = require('./util'),
     pathutil = util.pathutil,
-    config = util.configutil;
+    config = util.configutil,
+    fs = require('fs');
 
 
 var proto = {
@@ -164,7 +165,19 @@ var proto = {
         errorPages = config.errorPages || {};
 
         app.use(kraken.shutdown(app, this._config, errorPages['503']));
-        app.use(express.favicon());
+
+        var faviconDirs = [
+            config.static.rootPath,
+            config.static.srcRoot
+        ];
+        for(var i = 0, path; i < faviconDirs.length; i++) {
+            path = faviconDirs[i] + '/favicon.ico';
+            if(fs.existsSync(path)) {
+                app.use(express.favicon(path));
+                break;
+            }
+        }
+
         app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
         app.use(express.static(staticRoot));
         app.use(kraken.logger(config.logger));


### PR DESCRIPTION
No argument is sent to express.favicon which means it defaults to ../public/favicon.ico relative to the favicon middleware. That's nice if you're using connect directly but in my case connect is found in the express folder. I guess I could just add the same version of connect to my dependencies, but that seems like a shaky and error prone solution. 

This PR looks in the root projects .build and public folders instead and defaults to no favicon if none is found which also solves #47.
