### PR TITLE
Specialization while rendering

### DIFF
--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -1,20 +1,20 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2014 eBay Software Foundation                                │
-│                                                                             │
-│hh ,'""`.                                                                    │
-│  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │
-│  |(@)(@)|  you may not use this file except in compliance with the License. │
-│  )  __  (  You may obtain a copy of the License at                          │
-│ /,'))((`.\                                                                  │
-│(( ((  )) ))    http://www.apache.org/licenses/LICENSE-2.0                   │
-│ `\ `)(' /'                                                                  │
-│                                                                             │
-│   Unless required by applicable law or agreed to in writing, software       │
-│   distributed under the License is distributed on an "AS IS" BASIS,         │
-│   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
-│   See the License for the specific language governing permissions and       │
-│   limitations under the License.                                            │
-\*───────────────────────────────────────────────────────────────────────────*/
+ │  Copyright (C) 2013 eBay Software Foundation                                │
+ │                                                                             │
+ │hh ,'""`.                                                                    │
+ │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │
+ │  |(@)(@)|  you may not use this file except in compliance with the License. │
+ │  )  __  (  You may obtain a copy of the License at                          │
+ │ /,'))((`.\                                                                  │
+ │(( ((  )) ))    http://www.apache.org/licenses/LICENSE-2.0                   │
+ │ `\ `)(' /'                                                                  │
+ │                                                                             │
+ │   Unless required by applicable law or agreed to in writing, software       │
+ │   distributed under the License is distributed on an "AS IS" BASIS,         │
+ │   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
+ │   See the License for the specific language governing permissions and       │
+ │   limitations under the License.                                            │
+ \*───────────────────────────────────────────────────────────────────────────*/
 /*jshint maxstatements:35, maxcomplexity:10*/
 'use strict';
 
@@ -91,7 +91,7 @@ var proto = {
 
 
     _views: function () {
-        var app, config, i18n, cache, engines, module;
+        var app, config, i18n, specialization, cache, engines, module;
 
         /**
          * XXXXX ACHTUNG! ALERT! ALERT! PELIGRO! XXXXX
@@ -106,6 +106,7 @@ var proto = {
         // If i18n is enabled (config is available), set its cache
         // to the view cache value, and disable the view cache.
         i18n = config.get('i18n');
+        specialization = config.get('specialization');
         cache = config.get('express:view cache');
         if (i18n) {
             // Set i18n to the view engine cache settings. If the view
@@ -139,6 +140,10 @@ var proto = {
                 renderer = renderer(meta.settings);
             }
 
+            if (specialization) {
+                module = util.tryRequire('karka');
+                renderer = (module && module.setSpecializationWrapperForEngine(specialization, renderer)) || renderer;
+            }
             app.engine(ext, renderer);
         });
 
@@ -147,9 +152,8 @@ var proto = {
             // about the state of the current view engine in order to work. :/
             module = util.tryRequire('makara');
             i18n.contentPath = this._resolve(i18n.contentPath);
-            this._i18n = module && module.create(app, i18n);
+            this._templateProcessor =  module && module.create(app, i18n, specialization);
         }
-
     },
 
 
@@ -165,7 +169,7 @@ var proto = {
 
         app.use(kraken.shutdown(app, this._config, errorPages['503']));
         app.use(express.favicon());
-        app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
+        app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._templateProcessor));
         app.use(express.static(staticRoot));
         app.use(kraken.logger(config.logger));
 
@@ -173,12 +177,13 @@ var proto = {
             delegate.requestStart(app);
         }
 
-        app.use(express.json(config.json));
-        app.use(express.urlencoded(config.urlencoded));
+        config.bodyParser && console.warn('The `middleware:bodyParser` configuration will not be honored in future versions. Use `middleware:json`, `middleware:urlencoded`, and `middleware.multipart`.');
 
-        if (config.multipart) {
-            app.use(kraken.multipart(config.multipart.params));
-        }
+        app.use(express.json(config.bodyParser || config.json));
+        app.use(express.urlencoded(config.bodyParser || config.urlencoded));
+
+        console.warn('Multipart body parsing will be disabled by default in future versions. To enable, use `middleware:multipart` configuration.');
+        app.use(express.multipart(config.bodyParser || config.multipart || { limit: 2097152 })); // default to 2mb limit
 
         app.use(express.cookieParser(config.session.secret));
         app.use(kraken.session(config.session));

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
- │  Copyright (C) 2013 eBay Software Foundation                                │
+ │  Copyright (C) 2014 eBay Software Foundation                                │
  │                                                                             │
  │hh ,'""`.                                                                    │
  │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "grunt-contrib-clean": "~0.5.0",
     "nconf": "~0.6.8",
     "adaro": "~0.1.3",
-    "makara": "~0.3.0",
+    "makara": "git://github.com/pvenkatakrishnan/makara.git",
+    "karka": "git://github.com/pvenkatakrishnan/karka.git",
     "supertest": "~0.8.1"
   }
 }

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -61,6 +61,20 @@ describe('compiler', function () {
             .expect(VALID_LOCALIZED_TEMPLATE, next);
     });
 
+    it('should compile non-specialized template - jekyll', function (next) {
+        request(app)
+            .get('/templates/US/en/jekyll.js')
+            .expect('Content-Type', /javascript/)
+            .expect(200, next);
+    });
+
+    it('should compile a specialized template - hyde', function (next) {
+        request(app)
+            .get('/templates/US/en/hyde.js')
+            .expect('Content-Type', /javascript/)
+            .expect(200, next);
+    });
+
 
     it('should fail on a nonexistent template', function (next) {
         request(app)

--- a/test/fixtures/config/app.json
+++ b/test/fixtures/config/app.json
@@ -11,6 +11,16 @@
         "path": "path:./config/ssl/cert.pem",
         "file": "file:./config/ssl/key.pem",
         "base64": "base64:aGVsbG8gd29ybGQ="
-    }
+    },
 
+    "specialization": {
+        "jekyll": [
+            {
+                "template": "hyde",
+                "rules" : {
+                    "whoAmI": "BadGuy"
+                }
+            }
+        ]
+    }
 }

--- a/test/fixtures/controllers/controller.js
+++ b/test/fixtures/controllers/controller.js
@@ -44,4 +44,15 @@ module.exports = function (app) {
         res.send(200, 'ok');
     });
 
+    app.get('/jekyll', function (req, res) {
+
+        res.locals({
+            'whoAmI' : req.body.whoAmI
+        });
+
+        res.render('jekyll', {
+            title: 'Kraken unleashes split personality'
+        });
+    });
+
 };

--- a/test/fixtures/public/templates/hyde.dust
+++ b/test/fixtures/public/templates/hyde.dust
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><title>{title}</title></head><body><h1>Hyde here!</h1></body></html>

--- a/test/fixtures/public/templates/jekyll.dust
+++ b/test/fixtures/public/templates/jekyll.dust
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><title>{title}</title></head><body><h1>Jekyll here!</h1></body></html>

--- a/test/views.js
+++ b/test/views.js
@@ -13,6 +13,8 @@ describe('view', function () {
     var VALID_RESPONSE = '<!DOCTYPE html><html lang="en"><head><title>Hello, world</title></head><body><h1>node template test</h1></body></html>';
     var NOT_FOUND = '<h1>404 template</h1><p>/fourohfour</p>';
     var SERVER_ERROR = '<h1>500 template</h1><p>/ohnoes</p><p>uh oh</p>';
+    var JEKYLL = '<!DOCTYPE html><html lang="en"><head><title>Kraken unleashes split personality</title></head><body><h1>Jekyll here!</h1></body></html>';
+    var HYDE = '<!DOCTYPE html><html lang="en"><head><title>Kraken unleashes split personality</title></head><body><h1>Hyde here!</h1></body></html>';
 
     var cwd, src, bin, itses;
 
@@ -108,10 +110,62 @@ describe('view', function () {
             }
         },
 
-        'should support cached views': {
+        'should render specialized since context data matches the rules': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('express:view engine', 'dust');
+                    config.set('express:views', src);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/jekyll')
+                    .send({'whoAmI': 'BadGuy'})
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(HYDE, next);
+            }
+        },
+        'should render unspecialized since context data does not match the rules': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('express:view engine', 'dust');
+                    config.set('express:views', src);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/jekyll')
+                    .send({'whoAmI': 'GoodGuy'})
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(JEKYLL, next);
+            }
+        },
+        'should render specialized since context data matches the rules - with view engine js': {
             delegate: {
                 configure: function (config, callback) {
                     config.set('view engines:js:cache', true);
+                    config.set('express:view engine', 'js');
+                    config.set('express:views', bin);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/jekyll')
+                    .send({'whoAmI': 'BadGuy'})
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(HYDE, next);
+            }
+        },
+        'should support cached views': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('view engines:js:cache', false);
                     config.set('express:view engine', 'js');
                     config.set('express:views', bin);
                     callback();


### PR DESCRIPTION
Including template specialization before the middleware set in app.engine() is invoked,  during every res.render.
If  'specialization'  is specified in the app config,
the change, 
1. generates a template  map of specialized templates for that render context
2. stashes the map in the context under _specialization property

From there on the workflow is the same as before.
Will add more details when all the changes are PRed.
*****\* DO NOT MERGE THIS PR YET *****
 NEEDS PR TO MAKARA + KARKA MODULES TO WORK but will not break if merged as I do check for existence of the dependent rule parsing module. If not present will ignore the piece of code added below.

For the outside world who does not know yet what specialization work is for:
It is a mechanism to dynamically change views rendered in a specific context based on a rule set that can be specified in the app's config. A rule parser will evaluate the render context against the rules and decide which partial needs to be picked for the context.
This will be evaluated on every res.render('view', data)

Some use cases would be:
- A/B test a feature
- use different templates for different locales 
- Render different views based on the device the page is loaded
  ... and many more.
