### PR TITLE
Multipart: suppress file not found error when file was moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ A [Grunt](http://gruntjs.com/) task is used for builds. To prepare your code for
 
 Support for [multipart forms](http://en.wikipedia.org/wiki/File_select) is disabled by default. You can enable it by populating "multipart" in middleware.json and optionally pass parameters using [formidable's API](https://github.com/felixge/node-formidable).
 
+Files uploaded in a given request will populate in `req.files`.
+
 All temporary files uploaded will be automatically removed when the request is completed if you do not remove them yourself.
 
 # Contributing to the Kraken Suite

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -46,8 +46,10 @@ module.exports = function (settings) {
                                 if (exists) {
                                     fs.unlink(filePath, function (err) {
                                         if (err) {
-                                            console.error('Kraken failed to remove tmp file: ' + filePath);
-                                            console.error(err);
+                                            if (err.errno !== 34 && err.code !== 'ENOENT') { // ignore file not found error
+                                                console.error('Kraken failed to remove tmp file: ' + filePath);
+                                                console.error(err);
+                                            }
                                         }
                                     });
                                 }

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -20,69 +20,58 @@
 var formidable = require('formidable'),
     fs = require('fs'),
     settings,
-    req,
-    res,
-    next,
 
     multipart = function (settings) {
         settings = typeof settings === 'object' ? settings : {};
-        return function (request, response, callback) {
-            // declare these as module globals for later use
-            req = request;
-            res = response;
-            next = callback;
-
+        return function (req, res, next) {
             var form,
-                contentType = req.headers['content-type'];
+                contentType = req.headers['content-type'],
+                cleanupTempFiles = function () {
+                    var files = req.files;
+
+                    Object.keys(files).forEach(function (file) {
+                        var filePath = files[file].path,
+                            removeFile = function (exists) {
+                                if (exists) {
+                                    fs.unlink(filePath, fileRemoved);
+                                }
+                            },
+                            fileRemoved = function (err) {
+                                if (err) {
+                                    if (err.errno === 34 && err.code === 'ENOENT') {
+                                        return; // ignore file not found error
+                                    }
+                                    console.error('Kraken failed to remove tmp file: ' + filePath);
+                                    console.error(err);
+                                }
+                            };
+
+                        if (typeof filePath === 'string') {
+                            fs.exists(filePath, removeFile);
+                        }
+                    });
+                };
 
             if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
                 form = new formidable.IncomingForm(settings);
-                form.parse(req, formidableCallback);
+                form.parse(req, function (err, fields, files) {
+                    if (err) {
+                        next(err);
+                        return;
+                    }
+                    req.body = fields; // pass along form fields
+                    req.files = files; // pass along files
+
+                    // remove tmp files after request finishes
+                    res.once('finish', cleanupTempFiles);
+                    res.once('close', cleanupTempFiles);
+                    next();
+                });
             }
             else {
                 next();
             }
         };
-    },
-
-    formidableCallback = function (err, fields, files) {
-        if (err) {
-            next(err);
-            return;
-        }
-        req.body = fields; // pass along form fields
-        req.files = files; // pass along files
-
-        // remove tmp files after request finishes
-        res.once('finish', cleanupTempFiles);
-        res.once('close', cleanupTempFiles);
-        next();
-    },
-
-    cleanupTempFiles = function () {
-        var files = req.files;
-
-        Object.keys(files).forEach(function (file) {
-            var filePath = files[file].path,
-                removeFile = function (exists) {
-                    if (exists) {
-                        fs.unlink(filePath, fileRemoved);
-                    }
-                },
-                fileRemoved = function (err) {
-                    if (err) {
-                        if (err.errno === 34 && err.code === 'ENOENT') {
-                            return; // ignore file not found error
-                        }
-                        console.error('Kraken failed to remove tmp file: ' + filePath);
-                        console.error(err);
-                    }
-                };
-
-            if (typeof filePath === 'string') {
-                fs.exists(filePath, removeFile);
-            }
-        });
     };
 
 module.exports = multipart;

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -58,11 +58,11 @@ var formidable = require('formidable'),
         res.once('close', cleanupTempFiles);
         next();
     },
-    
+
     cleanupTempFiles = function () {
         var files = req.files;
 
-        Object.keys(req.files).forEach(function (file) {
+        Object.keys(files).forEach(function (file) {
             var filePath = files[file].path,
                 removeFile = function (exists) {
                     if (exists) {

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -20,58 +20,56 @@
 var formidable = require('formidable'),
     fs = require('fs'),
     settings,
-
-    multipart = function (settings) {
-        settings = typeof settings === 'object' ? settings : {};
-        return function (req, res, next) {
-            var form,
-                contentType = req.headers['content-type'],
-                cleanupTempFiles = function () {
-                    var files = req.files;
-
-                    Object.keys(files).forEach(function (file) {
-                        var filePath = files[file].path,
-                            removeFile = function (exists) {
-                                if (exists) {
-                                    fs.unlink(filePath, fileRemoved);
+    multipart = function (req, res, next) {
+        var form,
+            contentType = req.headers['content-type'],
+            cleanupTempFiles = function () {
+                var files = req.files;
+                Object.keys(files).forEach(function (file) {
+                    var filePath = files[file].path,
+                        removeFile = function (exists) {
+                            if (exists) {
+                                fs.unlink(filePath, fileRemoved);
+                            }
+                        },
+                        fileRemoved = function (err) {
+                            if (err) {
+                                if (err.errno === 34 && err.code === 'ENOENT') {
+                                    return; // ignore file not found error
                                 }
-                            },
-                            fileRemoved = function (err) {
-                                if (err) {
-                                    if (err.errno === 34 && err.code === 'ENOENT') {
-                                        return; // ignore file not found error
-                                    }
-                                    console.error('Kraken failed to remove tmp file: ' + filePath);
-                                    console.error(err);
-                                }
-                            };
+                                console.error('Kraken failed to remove tmp file: ' + filePath);
+                                console.error(err);
+                            }
+                        };
 
-                        if (typeof filePath === 'string') {
-                            fs.exists(filePath, removeFile);
-                        }
-                    });
-                };
-
-            if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
-                form = new formidable.IncomingForm(settings);
-                form.parse(req, function (err, fields, files) {
-                    if (err) {
-                        next(err);
-                        return;
+                    if (typeof filePath === 'string') {
+                        fs.exists(filePath, removeFile);
                     }
-                    req.body = fields; // pass along form fields
-                    req.files = files; // pass along files
-
-                    // remove tmp files after request finishes
-                    res.once('finish', cleanupTempFiles);
-                    res.once('close', cleanupTempFiles);
-                    next();
                 });
-            }
-            else {
+            };
+
+        if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
+            form = new formidable.IncomingForm(settings);
+            form.parse(req, function (err, fields, files) {
+                if (err) {
+                    next(err);
+                    return;
+                }
+                req.body = fields; // pass along form fields
+                req.files = files; // pass along files
+
+                // remove tmp files after request finishes
+                res.once('finish', cleanupTempFiles);
+                res.once('close', cleanupTempFiles);
                 next();
-            }
-        };
+            });
+        }
+        else {
+            next();
+        }
     };
 
-module.exports = multipart;
+module.exports = function (settings) {
+    settings = typeof settings === 'object' ? settings : {};
+    return multipart;
+};

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -70,10 +70,10 @@ var formidable = require('formidable'),
                     }
                 },
                 fileRemoved = function (err) {
-                    if (err && err.errno === 34 && err.code === 'ENOENT') {
-                        return; // ignore file not found error
-                    }
-                    else if (err) {
+                    if (err) {
+                        if (err.errno === 34 && err.code === 'ENOENT') {
+                            return; // ignore file not found error
+                        }
                         console.error('Kraken failed to remove tmp file: ' + filePath);
                         console.error(err);
                     }

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -18,56 +18,71 @@
 'use strict';
 
 var formidable = require('formidable'),
-    fs = require('fs');
+    fs = require('fs'),
+    settings,
+    req,
+    res,
+    next,
 
-module.exports = function (settings) {
-    settings = typeof settings === 'object' ? settings : {};
+    multipart = function (settings) {
+        settings = typeof settings === 'object' ? settings : {};
+        return function (request, response, callback) {
+            // declare these as module globals for later use
+            req = request;
+            res = response;
+            next = callback;
 
-    return function (req, res, next) {
-        var form = new formidable.IncomingForm(settings), contentType = req.headers['content-type'];
+            var form,
+                contentType = req.headers['content-type'];
 
-        if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
-            form.parse(req, function (err, fields, files) {
-                if (err) {
-                    next(err);
-                    return;
-                }
-                req.body = fields; // pass along form fields
-                req.files = files; // pass along files
-
-                // remove tmp files after request finishes
-                var cleanup = function () {
-
-                    // remove tmp file(s)
-                    Object.keys(files).forEach(function (file) {
-                        var filePath = files[file].path;
-                        if (typeof filePath === 'string') {
-                            fs.exists(filePath, function (exists) {
-                                if (exists) {
-                                    fs.unlink(filePath, function (err) {
-                                        if (err) {
-                                            if (err.errno === 34 && err.code === 'ENOENT') {
-                                                return; // ignore file not found error
-                                            }
-                                            else {
-                                                console.error('Kraken failed to remove tmp file: ' + filePath);
-                                                console.error(err);
-                                            }
-                                        }
-                                    });
-                                }
-                            });
-                        }
-                    });
-                };
-                res.once('finish', cleanup);
-                res.once('close', cleanup);
+            if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
+                form = new formidable.IncomingForm(settings);
+                form.parse(req, formidableCallback);
+            }
+            else {
                 next();
-            });
+            }
+        };
+    },
+
+    formidableCallback = function (err, fields, files) {
+        if (err) {
+            next(err);
+            return;
         }
-        else {
-            next();
-        }
+        req.body = fields; // pass along form fields
+        req.files = files; // pass along files
+
+        // remove tmp files after request finishes
+        res.once('finish', cleanupTempFiles);
+        res.once('close', cleanupTempFiles);
+        next();
+    },
+    
+    cleanupTempFiles = function () {
+        var files = req.files;
+
+        Object.keys(req.files).forEach(function (file) {
+            var filePath = files[file].path,
+                removeFile = function (exists) {
+                    if (exists) {
+                        fs.unlink(filePath, fileRemoved);
+                    }
+                },
+                fileRemoved = function (err) {
+                    if (err && err.errno === 34 && err.code === 'ENOENT') {
+                        return; // ignore file not found error
+                    }
+                    else if (err) {
+                        console.error('Kraken failed to remove tmp file: ' + filePath);
+                        console.error(err);
+                    }
+                };
+
+            if (typeof filePath === 'string') {
+                fs.exists(filePath, removeFile);
+            }
+        });
     };
 
-};
+module.exports = multipart;

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -46,7 +46,7 @@ module.exports = function (settings) {
                                 if (exists) {
                                     fs.unlink(filePath, function (err) {
                                         if (err) {
-                                            if (err.errno !== 34 && err.code !== 'ENOENT') {
+                                            if (err.errno === 34 && err.code === 'ENOENT') {
                                                 return; // ignore file not found error
                                             }
                                             else {

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -47,7 +47,7 @@ module.exports = function (settings) {
                                     fs.unlink(filePath, function (err) {
                                         if (err) {
                                             if (err.errno !== 34 && err.code !== 'ENOENT') {
-                                              return; // ignore file not found error
+                                                return; // ignore file not found error
                                             }
                                             else {
                                                 console.error('Kraken failed to remove tmp file: ' + filePath);

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -46,7 +46,10 @@ module.exports = function (settings) {
                                 if (exists) {
                                     fs.unlink(filePath, function (err) {
                                         if (err) {
-                                            if (err.errno !== 34 && err.code !== 'ENOENT') { // ignore file not found error
+                                            if (err.errno !== 34 && err.code !== 'ENOENT') {
+                                              return; // ignore file not found error
+                                            }
+                                            else {
                                                 console.error('Kraken failed to remove tmp file: ' + filePath);
                                                 console.error(err);
                                             }

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -18,52 +18,71 @@
 'use strict';
 
 var formidable = require('formidable'),
-    fs = require('fs');
+    fs = require('fs'),
+    settings,
+    req,
+    res,
+    next,
 
-module.exports = function (settings) {
-    settings = typeof settings === 'object' ? settings : {};
+    multipart = function (settings) {
+        settings = typeof settings === 'object' ? settings : {};
+        return function (request, response, callback) {
+            // declare these as module globals for later use
+            req = request;
+            res = response;
+            next = callback;
 
-    return function (req, res, next) {
-        var form, contentType = req.headers['content-type'];
+            var form,
+                contentType = req.headers['content-type'];
 
-        if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
-            form = new formidable.IncomingForm(settings);
-            form.parse(req, function (err, fields, files) {
-                if (err) {
-                    next(err);
-                    return;
-                }
-                req.body = fields; // pass along form fields
-                req.files = files; // pass along files
-
-                // remove tmp files after request finishes
-                var cleanup = function () {
-
-                    // remove tmp file(s)
-                    Object.keys(files).forEach(function (file) {
-                        var filePath = files[file].path;
-                        if (typeof filePath === 'string') {
-                            fs.exists(filePath, function (exists) {
-                                if (exists) {
-                                    fs.unlink(filePath, function (err) {
-                                        if (err) {
-                                            console.error('Kraken failed to remove tmp file: ' + filePath);
-                                            console.error(err);
-                                        }
-                                    });
-                                }
-                            });
-                        }
-                    });
-                };
-                res.once('finish', cleanup);
-                res.once('close', cleanup);
+            if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
+                form = new formidable.IncomingForm(settings);
+                form.parse(req, formidableCallback);
+            }
+            else {
                 next();
-            });
+            }
+        };
+    },
+
+    formidableCallback = function (err, fields, files) {
+        if (err) {
+            next(err);
+            return;
         }
-        else {
-            next();
-        }
+        req.body = fields; // pass along form fields
+        req.files = files; // pass along files
+
+        // remove tmp files after request finishes
+        res.once('finish', cleanupTempFiles);
+        res.once('close', cleanupTempFiles);
+        next();
+    },
+    
+    cleanupTempFiles = function () {
+        var files = req.files;
+
+        Object.keys(req.files).forEach(function (file) {
+            var filePath = files[file].path,
+                removeFile = function (exists) {
+                    if (exists) {
+                        fs.unlink(filePath, fileRemoved);
+                    }
+                },
+                fileRemoved = function (err) {
+                    if (err && err.errno === 34 && err.code === 'ENOENT') {
+                        return; // ignore file not found error
+                    }
+                    else if (err) {
+                        console.error('Kraken failed to remove tmp file: ' + filePath);
+                        console.error(err);
+                    }
+                };
+
+            if (typeof filePath === 'string') {
+                fs.exists(filePath, removeFile);
+            }
+        });
     };
 
-};
+module.exports = multipart;

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -24,9 +24,10 @@ module.exports = function (settings) {
     settings = typeof settings === 'object' ? settings : {};
 
     return function (req, res, next) {
-        var form = new formidable.IncomingForm(settings), contentType = req.headers['content-type'];
+        var form, contentType = req.headers['content-type'];
 
         if (typeof contentType === 'string' && contentType.indexOf('multipart/form-data') > -1) {
+            form = new formidable.IncomingForm(settings);
             form.parse(req, function (err, fields, files) {
                 if (err) {
                     next(err);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "engineStrict": true,
   "dependencies": {
     "express-enrouten": "~0.0.3",
-    "formidable ": "~1.0.14",
+    "formidable": "~1.0.14",
     "lusca": "~0.1.1",
     "kraken-devtools": "~0.0.3",
     "mkdirp": "~0.3.5",


### PR DESCRIPTION
I've found that when you move files out of the /tmp directory in one of your routes, the multipart middleware will attempt to remove them too later and when it fails to do so it will log an error.

This patch prevents that by disabling the error logging when the specific error is the file not found error.

Since the goal of that section of the middleware is to remove the tmp file, if it's already gone, there is no need to log the error.

For some reason this cannot be done more directly, as in my testing it makes it past the `fs.exists` check successfully despite the file not actually existing. Could be a race condition.
