### PR TITLE
Add support for mount point or express route config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ module.exports = function (options) {
 
         // Remove sacrificial express app
         parent.stack.pop();
+        parent.route = app.route;
 
         deferred = Q.defer();
         complete = deferred.resolve.bind(deferred);

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -26,7 +26,7 @@ module.exports = function middleware(app) {
 
     debug('initializing middleware');
     config = app.kraken.get('middleware') || {};
-    app.use(meddleware(config));
+    app.use(app.route, meddleware(config));
 
     return app;
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -138,6 +138,7 @@ module.exports = function (app, options) {
         app.set('env', settings.get('env:env'));
         app.set('view', settings.get('express:view') ? require(settings.get('express:view')) : View);
         app.kraken = settings;
+        app.route = (app.settings.route && app.settings.route !== '/') ? app.settings.route : app.route;
 
         debug('express settings\n', app.settings);
         return app;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "caller": "~0.0.1",
-    "meddleware": "~0.1.0",
+    "meddleware": "git://github.com/paypal/meddleware.git#routes",
     "shortstop": "~0.0.1",
     "shortstop-handlers": "~0.1.0",
     "endgame": "~0.0.3",
@@ -80,7 +80,7 @@
     "nconf": "~0.6.9",
     "shush": "~0.0.1",
     "lusca": "~0.1.1",
-    "express-enrouten": "~0.2.0",
+    "express-enrouten": "git://github.com/paypal/express-enrouten.git#root",
     "core-util-is": "~1.0.1",
     "formidable": "~1.0.14",
     "readdirp": "~0.3.3"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "caller": "~0.0.1",
-    "meddleware": "git://github.com/paypal/meddleware.git#routes",
+    "meddleware": "~0.1.1",
     "shortstop": "~0.0.1",
     "shortstop-handlers": "~0.1.0",
     "endgame": "~0.0.3",
@@ -80,7 +80,7 @@
     "nconf": "~0.6.9",
     "shush": "~0.0.1",
     "lusca": "~0.1.1",
-    "express-enrouten": "git://github.com/paypal/express-enrouten.git#root",
+    "express-enrouten": "~0.3.0",
     "core-util-is": "~1.0.1",
     "formidable": "~1.0.14",
     "readdirp": "~0.3.3"

--- a/test/fixtures/middleware/config/middleware.json
+++ b/test/fixtures/middleware/config/middleware.json
@@ -1,6 +1,5 @@
 {
     "middleware": {
-        /* Removed for development purposes only */
         "shutdown": {
             "module": "path:../../../middleware/shutdown"
         },

--- a/test/fixtures/mount/routes.js
+++ b/test/fixtures/mount/routes.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (app) {
+
+    app.get('/', function (req, res) {
+        res.send('ok');
+    });
+
+};

--- a/test/kraken.js
+++ b/test/kraken.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var test = require('tape'),
+    path = require('path'),
     kraken = require('../'),
     nconf = require('nconf'),
     express = require('express'),
@@ -75,6 +76,70 @@ test('kraken', function (t) {
         app.on('start', start);
         app.on('error', error);
         app.use(kraken({ basedir: __dirname }));
+    });
+
+
+    t.test('mount point', function (t) {
+        var options, app, server;
+
+        t.plan(2);
+        t.on('end', reset);
+
+        function start() {
+            t.pass('server started');
+            server = request(app).get('/foo/').expect(200, 'ok', function (err) {
+                t.error(err);
+                server.app.close(t.end.bind(t));
+            });
+        }
+
+        function error(err) {
+            t.error(err, 'server startup failed');
+            t.end();
+        }
+
+        options = {
+            basedir: path.join(__dirname, 'fixtures', 'mount')
+        };
+
+        app = express();
+        app.on('start', start);
+        app.on('error', error);
+        app.use('/foo', kraken(options));
+    });
+
+
+    t.test('express route', function (t) {
+        var options, app, server;
+
+        t.plan(2);
+        t.on('end', reset);
+
+        function start() {
+            t.pass('server started');
+            server = request(app).get('/foo/').expect(200, 'ok', function (err) {
+                t.error(err);
+                server.app.close(t.end.bind(t));
+            });
+        }
+
+        function error(err) {
+            t.error(err, 'server startup failed');
+            t.end();
+        }
+
+        options = {
+            basedir: path.join(__dirname, 'fixtures', 'mount'),
+            onconfig: function (settings, cb) {
+                settings.set('express:route', '/foo');
+                cb(null, settings);
+            }
+        };
+
+        app = express();
+        app.on('start', start);
+        app.on('error', error);
+        app.use(kraken(options));
     });
 
 


### PR DESCRIPTION
Currently, if someone chooses to use kraken with a particular root path, middleware will not be registered as expected.

This PR adds support for specifying a base route when using this module. Add middleware and routes will be mounted on the specified path.

This PR adds support for 2 ways of specifying mount point:

``` javascript
app.use('/foo', kraken());
```

or

``` json
{
    "express": {
        "route": "/foo"
    }
}
```

NOTE: This change depends on as-yet-unreleased patches to `express-enrouten` and `meddleware`.
