### PR TITLE
Kraken.use.engine munger

### DIFF
--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -148,13 +148,13 @@ var proto = {
             }, renderer)) || renderer);
         });
 
-        if (i18n) {
+        /*if (i18n) {
             // After all engines are registered, apply i18n. It needs to know
             // about the state of the current view engine in order to work. :/
             module = util.tryRequire('makara');
             i18n.contentPath = this._resolve(i18n.contentPath);
             this._templateProcessor =  module && module.create(app, i18n, specialization);
-        }
+        }*/
 
     },
 

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -91,7 +91,7 @@ var proto = {
 
 
     _views: function () {
-        var app, config, i18n, cache, engines, module;
+        var app, config, i18n, specialization, cache, engines, module;
 
         /**
          * XXXXX ACHTUNG! ALERT! ALERT! PELIGRO! XXXXX
@@ -106,6 +106,7 @@ var proto = {
         // If i18n is enabled (config is available), set its cache
         // to the view cache value, and disable the view cache.
         i18n = config.get('i18n');
+        specialization = config.get('specialization');
         cache = config.get('express:view cache');
         if (i18n) {
             // Set i18n to the view engine cache settings. If the view
@@ -139,6 +140,10 @@ var proto = {
                 renderer = renderer(meta.settings);
             }
 
+            if (specialization) {
+                module = util.tryRequire('karka');
+                renderer = (module && module.setSpecializationWrapperForEngine(specialization, renderer)) || renderer;
+            }
             app.engine(ext, renderer);
         });
 
@@ -147,7 +152,7 @@ var proto = {
             // about the state of the current view engine in order to work. :/
             module = util.tryRequire('makara');
             i18n.contentPath = this._resolve(i18n.contentPath);
-            this._i18n = module && module.create(app, i18n);
+            this._templateProcessor =  module && module.create(app, i18n, specialization);
         }
 
     },
@@ -165,7 +170,7 @@ var proto = {
 
         app.use(kraken.shutdown(app, this._config, errorPages['503']));
         app.use(express.favicon());
-        app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._i18n));
+        app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._templateProcessor));
         app.use(express.static(staticRoot));
         app.use(kraken.logger(config.logger));
 

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -142,7 +142,7 @@ var proto = {
 
             if (specialization) {
                 module = util.tryRequire('karka');
-                renderer = (module && module.create(specialization, renderer).renderer) || renderer;
+                renderer = (module && module.create(specialization).renderer(renderer)) || renderer;
             }
             app.engine(ext, renderer);
         });

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -147,15 +147,6 @@ var proto = {
                 specialization: specialization
             }, renderer)) || renderer);
         });
-
-        /*if (i18n) {
-            // After all engines are registered, apply i18n. It needs to know
-            // about the state of the current view engine in order to work. :/
-            module = util.tryRequire('makara');
-            i18n.contentPath = this._resolve(i18n.contentPath);
-            this._templateProcessor =  module && module.create(app, i18n, specialization);
-        }*/
-
     },
 
 
@@ -171,7 +162,7 @@ var proto = {
 
         app.use(kraken.shutdown(app, this._config, errorPages['503']));
         app.use(express.favicon());
-        app.use(kraken.compiler(srcRoot, staticRoot, this._config, this._templateProcessor));
+        app.use(kraken.compiler(srcRoot, staticRoot, this._config));
         app.use(express.static(staticRoot));
         app.use(kraken.logger(config.logger));
 

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -142,7 +142,7 @@ var proto = {
 
             if (specialization) {
                 module = util.tryRequire('karka');
-                renderer = (module && module.setSpecializationWrapperForEngine(specialization, renderer)) || renderer;
+                renderer = (module && module.create(specialization, renderer).renderer) || renderer;
             }
             app.engine(ext, renderer);
         });

--- a/lib/appcore.js
+++ b/lib/appcore.js
@@ -26,7 +26,8 @@ var Q = require('q'),
     kraken = require('./middleware'),
     util = require('./util'),
     pathutil = util.pathutil,
-    config = util.configutil;
+    config = util.configutil,
+    engineMunger = require('engine-munger');
 
 
 var proto = {
@@ -124,7 +125,7 @@ var proto = {
         // Register each rendering engine
         engines = config.get('view engines');
         Object.keys(engines).forEach(function (ext) {
-            var meta, engine, renderer;
+            var meta, engine, renderer, renderWrapper;
 
             meta = engines[ext];
             engine = require(meta.module);
@@ -140,11 +141,11 @@ var proto = {
                 renderer = renderer(meta.settings);
             }
 
-            if (specialization) {
-                module = util.tryRequire('karka');
-                renderer = (module && module.create(specialization).renderer(renderer)) || renderer;
-            }
-            app.engine(ext, renderer);
+            renderWrapper = engineMunger[app.get('view engine')];
+            app.engine(ext, (renderWrapper && renderWrapper(app, {
+                i18n: i18n,
+                specialization: specialization
+            }, renderer)) || renderer);
         });
 
         if (i18n) {

--- a/lib/middleware/compiler.js
+++ b/lib/middleware/compiler.js
@@ -22,17 +22,25 @@ var fs = require('fs'),
     rimraf = require('rimraf'),
     mkdirp = require('mkdirp'),
     devtools = require('kraken-devtools'),
-    util = require('../util');
+    util = require('../util'),
+    localizr = require('localizr'),
+    resolvr = require('fileResolver');
 
 
-module.exports = function (srcRoot, destRoot, config, intl) {
-    var i18n, dust, options, directory;
+module.exports = function (srcRoot, destRoot, config) {
+    var i18n, dust, options, directory, propResolvr;
 
     i18n = config.get('i18n');
     dust = util.tryRequire('dustjs-linkedin');
     options = config.get('middleware:compiler');
     directory = options && options.dust;
 
+    console.info('****i18n', i18n);
+    propResolvr = resolvr.create({
+        root: i18n.contentPath || i18n.contentRoot,
+        ext: 'properties',
+        fallback: i18n.fallback || i18n.fallbackLocale
+    });
 
     if (i18n && util.tryRequire('makara') && dust && directory) {
 
@@ -41,7 +49,7 @@ module.exports = function (srcRoot, destRoot, config, intl) {
             dir: directory,
 
             precompile: function (context, callback) {
-                var locality, locale, dest;
+                var locality, locale, dest, src;
 
                 // Look for Country/Locale tuple in path
                 locale = context.name.match(/(?:([A-Za-z]{2})\/([A-Za-z]{2})\/)?(.*)/);
@@ -56,15 +64,58 @@ module.exports = function (srcRoot, destRoot, config, intl) {
                     context.name = locale[3];
                 }
 
+                src = path.join(config.get('express:views'), context.name + '.dust');
+
                 // Store original source root and switch it so a tmp directory.
                 context.origSrcRoot = context.srcRoot;
                 context.srcRoot = path.join(context.srcRoot, 'tmp');
 
+                //handle the template not found case
+                if (!fs.existsSync(src)) {
+                    callback(null, context);
+                    return;
+                }
+
                 // Determine the interim tempfile (a preprocessed dust file)
                 dest = path.join(context.srcRoot, context.filePath);
                 dest = dest.replace(path.extname(dest), '') + '.dust';
+                var resolved = propResolvr.resolve(context.name, locality);
 
-                intl.localize(context.name, locality, function (err, data) {
+                console.info('src:', src);
+                console.info('dest:', dest);
+                try {
+                    //if we have a corresponding property file then translate
+                    if (resolved.file) {
+                        var opt = {
+                            src: src,
+                            props: resolved.file
+                        };
+                        mkdirp(path.dirname(dest), function (err) {
+                            if (err) {
+                                callback(err);
+                                return;
+                            }
+                            localizr.createReadStream(opt).pipe(fs.createWriteStream(dest));
+                            callback(null, context);
+                        });
+                    } else {
+                        //else just use the src file directly
+                        mkdirp(path.dirname(dest), function (err) {
+                            if (err) {
+                                callback(err);
+                                return;
+                            }
+                            fs.createReadStream(src).pipe(fs.createWriteStream(dest));
+                            callback(null, context);
+                        });
+                    }
+                }
+                catch (e) {
+                    callback(e);
+                }
+
+
+                /*intl.localize(context.name, locality, function (err, data) {
                     if (err) {
                         callback(err);
                         return;
@@ -80,7 +131,8 @@ module.exports = function (srcRoot, destRoot, config, intl) {
                         });
                     });
 
-                });
+                });*/
+
 
             },
 

--- a/lib/middleware/compiler.js
+++ b/lib/middleware/compiler.js
@@ -23,18 +23,18 @@ var fs = require('fs'),
     mkdirp = require('mkdirp'),
     devtools = require('kraken-devtools'),
     util = require('../util'),
-    localizr = require('localizr'),
     resolvr = require('fileResolver'),
     concat = require('concat-stream');
 
 
 module.exports = function (srcRoot, destRoot, config) {
-    var i18n, dust, options, directory, propResolvr;
+    var i18n, dust, options, directory, propResolvr, localizr;
 
     i18n = config.get('i18n');
     dust = util.tryRequire('dustjs-linkedin');
     options = config.get('middleware:compiler');
     directory = options && options.dust;
+    localizr = util.tryRequire('localizr');
 
     propResolvr = resolvr.create({
         root: i18n.contentPath || i18n.contentRoot,
@@ -42,7 +42,7 @@ module.exports = function (srcRoot, destRoot, config) {
         fallback: i18n.fallback || i18n.fallbackLocale
     });
 
-    if (i18n && dust && directory) {
+    if (i18n && dust && directory && localizr) {
 
         options.dust = {
 

--- a/lib/middleware/compiler.js
+++ b/lib/middleware/compiler.js
@@ -36,14 +36,13 @@ module.exports = function (srcRoot, destRoot, config) {
     options = config.get('middleware:compiler');
     directory = options && options.dust;
 
-    console.info('****i18n', i18n);
     propResolvr = resolvr.create({
         root: i18n.contentPath || i18n.contentRoot,
         ext: 'properties',
         fallback: i18n.fallback || i18n.fallbackLocale
     });
 
-    if (i18n && util.tryRequire('makara') && dust && directory) {
+    if (i18n && dust && directory) {
 
         options.dust = {
 
@@ -122,27 +121,6 @@ module.exports = function (srcRoot, destRoot, config) {
                 catch (e) {
                     callback(e);
                 }
-
-
-                /*intl.localize(context.name, locality, function (err, data) {
-                    if (err) {
-                        callback(err);
-                        return;
-                    }
-
-                    mkdirp(path.dirname(dest), function (err) {
-                        if (err) {
-                            callback(err);
-                            return;
-                        }
-                        fs.writeFile(dest, data, function (err) {
-                            callback(err, context);
-                        });
-                    });
-
-                });*/
-
-
             },
 
             postcompile: function (context, callback) {

--- a/lib/middleware/compiler.js
+++ b/lib/middleware/compiler.js
@@ -24,7 +24,8 @@ var fs = require('fs'),
     devtools = require('kraken-devtools'),
     util = require('../util'),
     localizr = require('localizr'),
-    resolvr = require('fileResolver');
+    resolvr = require('fileResolver'),
+    concat = require('concat-stream');
 
 
 module.exports = function (srcRoot, destRoot, config) {
@@ -81,8 +82,6 @@ module.exports = function (srcRoot, destRoot, config) {
                 dest = dest.replace(path.extname(dest), '') + '.dust';
                 var resolved = propResolvr.resolve(context.name, locality);
 
-                console.info('src:', src);
-                console.info('dest:', dest);
                 try {
                     //if we have a corresponding property file then translate
                     if (resolved.file) {
@@ -91,12 +90,22 @@ module.exports = function (srcRoot, destRoot, config) {
                             props: resolved.file
                         };
                         mkdirp(path.dirname(dest), function (err) {
+                            var out;
                             if (err) {
                                 callback(err);
                                 return;
                             }
-                            localizr.createReadStream(opt).pipe(fs.createWriteStream(dest));
-                            callback(null, context);
+                            out = concat({ encoding: 'string' }, function (data) {
+                                fs.writeFile(dest, data, function (err) {
+                                    if (err) {
+                                        callback(err);
+                                        return;
+                                    }
+                                    callback(null, context);
+                                });
+                            });
+                            localizr.createReadStream(opt).pipe(out);
+
                         });
                     } else {
                         //else just use the src file directly

--- a/lib/middleware/compiler.js
+++ b/lib/middleware/compiler.js
@@ -70,7 +70,7 @@ module.exports = function (srcRoot, destRoot, config) {
                 context.origSrcRoot = context.srcRoot;
                 context.srcRoot = path.join(context.srcRoot, 'tmp');
 
-                //handle the template not found case
+                //ignore processing if the template is not found
                 if (!fs.existsSync(src)) {
                     callback(null, context);
                     return;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "shortstop": "0.0.1",
     "engine-munger": "git://github.com/pvenkatakrishnan/engine-munger.git",
     "fileResolver": "git://github.com/pvenkatakrishnan/fileResolver.git",
-    "localizr": "git://github.com/totherik/localizr.git",
     "concat-stream": "~1.4.1"
   },
   "peerDependencies": {
@@ -82,6 +81,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "nconf": "~0.6.8",
     "adaro": "~0.1.3",
+    "localizr": "git://github.com/totherik/localizr.git",
     "karka": "git://github.com/pvenkatakrishnan/karka.git#karka-without-context",
     "supertest": "~0.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "q": "~0.9.7",
     "jsonminify": "~0.2.2",
     "shortstop": "0.0.1",
-    "engine-munger": "git://github.com/pvenkatakrishnan/engine-munger.git"
+    "engine-munger": "git://github.com/pvenkatakrishnan/engine-munger.git",
+    "concat-stream": "~1.4.1"
   },
   "peerDependencies": {
     "express": "~3.4",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "jsonminify": "~0.2.2",
     "shortstop": "0.0.1",
     "engine-munger": "git://github.com/pvenkatakrishnan/engine-munger.git",
+    "fileResolver": "git://github.com/pvenkatakrishnan/fileResolver.git",
+    "localizr": "git://github.com/totherik/localizr.git",
     "concat-stream": "~1.4.1"
   },
   "peerDependencies": {
@@ -80,8 +82,6 @@
     "grunt-contrib-clean": "~0.5.0",
     "nconf": "~0.6.8",
     "adaro": "~0.1.3",
-    "makara": "git://github.com/pvenkatakrishnan/makara.git",
-    "engine-munger": "git://github.com/pvenkatakrishnan/engine-munger.git",
     "karka": "git://github.com/pvenkatakrishnan/karka.git#karka-without-context",
     "supertest": "~0.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "grunt-contrib-clean": "~0.5.0",
     "nconf": "~0.6.8",
     "adaro": "~0.1.3",
-    "makara": "~0.3.0",
+    "makara": "git://github.com/pvenkatakrishnan/makara.git",
+    "karka": "git://github.com/pvenkatakrishnan/karka.git",
     "supertest": "~0.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "rimraf": "~2.2.2",
     "q": "~0.9.7",
     "jsonminify": "~0.2.2",
-    "shortstop": "0.0.1"
+    "shortstop": "0.0.1",
+    "engine-munger": "git://github.com/pvenkatakrishnan/engine-munger.git"
   },
   "peerDependencies": {
     "express": "~3.4",
@@ -79,7 +80,8 @@
     "nconf": "~0.6.8",
     "adaro": "~0.1.3",
     "makara": "git://github.com/pvenkatakrishnan/makara.git",
-    "karka": "git://github.com/pvenkatakrishnan/karka.git",
+    "engine-munger": "git://github.com/pvenkatakrishnan/engine-munger.git",
+    "karka": "git://github.com/pvenkatakrishnan/karka.git#karka-without-context",
     "supertest": "~0.8.1"
   }
 }

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -61,6 +61,20 @@ describe('compiler', function () {
             .expect(VALID_LOCALIZED_TEMPLATE, next);
     });
 
+    it('should compile non-specialized template - jekyll', function (next) {
+        request(app)
+            .get('/templates/US/en/jekyll.js')
+            .expect('Content-Type', /javascript/)
+            .expect(200, next);
+    });
+
+    it('should compile a specialized template - hyde', function (next) {
+        request(app)
+            .get('/templates/US/en/hyde.js')
+            .expect('Content-Type', /javascript/)
+            .expect(200, next);
+    });
+
 
     it('should fail on a nonexistent template', function (next) {
         request(app)

--- a/test/fixtures/config/app.json
+++ b/test/fixtures/config/app.json
@@ -11,6 +11,16 @@
         "path": "path:./config/ssl/cert.pem",
         "file": "file:./config/ssl/key.pem",
         "base64": "base64:aGVsbG8gd29ybGQ="
-    }
+    },
 
+    "specialization": {
+        "jekyll": [
+            {
+                "template": "hyde",
+                "rules" : {
+                    "whoAmI": "BadGuy"
+                }
+            }
+        ]
+    }
 }

--- a/test/fixtures/controllers/controller.js
+++ b/test/fixtures/controllers/controller.js
@@ -44,4 +44,15 @@ module.exports = function (app) {
         res.send(200, 'ok');
     });
 
+    app.get('/jekyll', function (req, res) {
+
+        res.locals({
+            'whoAmI' : req.body.whoAmI
+        });
+
+        res.render('jekyll', {
+            title: 'Kraken unleashes split personality'
+        });
+    });
+
 };

--- a/test/fixtures/public/templates/hyde.dust
+++ b/test/fixtures/public/templates/hyde.dust
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><title>{title}</title></head><body><h1>Hyde here!</h1></body></html>

--- a/test/fixtures/public/templates/jekyll.dust
+++ b/test/fixtures/public/templates/jekyll.dust
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><title>{title}</title></head><body><h1>Jekyll here!</h1></body></html>

--- a/test/views.js
+++ b/test/views.js
@@ -43,7 +43,7 @@ describe('view', function () {
     }
 
 
-    /*itses = {
+   /* itses = {
         'should use the default view engine (dust)': {
             delegate: {
                 configure: function (config, callback) {

--- a/test/views.js
+++ b/test/views.js
@@ -13,6 +13,8 @@ describe('view', function () {
     var VALID_RESPONSE = '<!DOCTYPE html><html lang="en"><head><title>Hello, world</title></head><body><h1>node template test</h1></body></html>';
     var NOT_FOUND = '<h1>404 template</h1><p>/fourohfour</p>';
     var SERVER_ERROR = '<h1>500 template</h1><p>/ohnoes</p><p>uh oh</p>';
+    var JEKYLL = '<!DOCTYPE html><html lang="en"><head><title>Kraken unleashes split personality</title></head><body><h1>Jekyll here!</h1></body></html>';
+    var HYDE = '<!DOCTYPE html><html lang="en"><head><title>Kraken unleashes split personality</title></head><body><h1>Hyde here!</h1></body></html>';
 
     var cwd, src, bin, itses;
 
@@ -108,10 +110,62 @@ describe('view', function () {
             }
         },
 
-        'should support cached views': {
+        'should render specialized since context data matches the rules': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('express:view engine', 'dust');
+                    config.set('express:views', src);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/jekyll')
+                    .send({'whoAmI': 'BadGuy'})
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(HYDE, next);
+            }
+        },
+        'should render unspecialized since context data does not match the rules': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('express:view engine', 'dust');
+                    config.set('express:views', src);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/jekyll')
+                    .send({'whoAmI': 'GoodGuy'})
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(JEKYLL, next);
+            }
+        },
+        'should render specialized since context data matches the rules - with view engine js': {
             delegate: {
                 configure: function (config, callback) {
                     config.set('view engines:js:cache', true);
+                    config.set('express:view engine', 'js');
+                    config.set('express:views', bin);
+                    callback();
+                }
+            },
+            assert:  function (app, next) {
+                request(app)
+                    .get('/jekyll')
+                    .send({'whoAmI': 'BadGuy'})
+                    .expect(200)
+                    .expect('Content-Type', /html/)
+                    .expect(HYDE, next);
+            }
+        },
+        'should support cached views': {
+            delegate: {
+                configure: function (config, callback) {
+                    config.set('view engines:js:cache', false);
                     config.set('express:view engine', 'js');
                     config.set('express:views', bin);
                     callback();

--- a/test/views.js
+++ b/test/views.js
@@ -43,7 +43,7 @@ describe('view', function () {
     }
 
 
-   /* itses = {
+    itses = {
         'should use the default view engine (dust)': {
             delegate: {
                 configure: function (config, callback) {
@@ -315,6 +315,6 @@ describe('view', function () {
 
             run(test.delegate, success, next);
         });
-    });*/
+    });
 
 });

--- a/test/views.js
+++ b/test/views.js
@@ -43,7 +43,7 @@ describe('view', function () {
     }
 
 
-    itses = {
+    /*itses = {
         'should use the default view engine (dust)': {
             delegate: {
                 configure: function (config, callback) {
@@ -315,6 +315,6 @@ describe('view', function () {
 
             run(test.delegate, success, next);
         });
-    });
+    });*/
 
 });


### PR DESCRIPTION
An approach to not using makara/karka directly in kraken and instead splitting functionalities for i18n/specialization into multiple small modules.

Todos before merging this PR:
- [ ] Publishing localizr https://github.com/totherik/localizr
- [ ] Publishing engine-munger https://github.com/pvenkatakrishnan/engine-munger
- [ ] Publishing Karka https://github.com/pvenkatakrishnan/karka
- [ ] Hooking travis CI and Publishing fileResolver https://github.com/pvenkatakrishnan/fileResolver
