### PR TITLE
Adding express to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "nconf": "~0.6.8",
     "adaro": "~0.1.3",
     "makara": "~0.3.0",
-    "supertest": "~0.8.1"
+    "supertest": "~0.8.1",
+    "express": "~3.4"
   }
 }


### PR DESCRIPTION
This is fixed fully in the 1.0 branch by untangling the express/lusca/kraken dependency, but in the meantime this resolves the following error when running `npm install` for kraken:

```
npm ERR! peerinvalid The package express does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer lusca@0.1.1 wants express@*
```

Express is listed as a peerDependency, but is not installed directly when testing locally. Adding it to a devDependency solves this.
