### PR TITLE
Shortstop update

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,8 @@ function createHandlers(options) {
         base64:  handlers.base64(),
         env:     handlers.env(),
         require: handlers.require(options.basedir),
-        exec:    handlers.exec(options.basedir)
+        exec:    handlers.exec(options.basedir),
+        glob:    handlers.glob(options.basedir)
     };
 
     Object.keys(options.protocols).forEach(function (protocol) {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "caller": "~0.0.1",
     "meddleware": "^1.0.0",
-    "shortstop-handlers": "^0.1.0",
+    "shortstop-handlers": "^1.0.0",
     "endgame": "^0.0.3",
     "debuglog": "~0.0.2",
     "shush": "~0.0.1",


### PR DESCRIPTION
- Upgrade `shortstop-handlers` to `^1.0.0`
- Add support for globs out of the box.
