### PR TITLE
Adding fix and regression test for `trust proxy fn` clobbering

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -30,6 +30,7 @@ module.exports = function settings(app, options) {
         app.settings = app.locals.settings = config.get('express');
         app.set('env', config.get('env:env'));
         app.set('view', config.get('express:view') ? require(config.get('express:view')) : View);
+        app.set('trust proxy', config.get('express:trust proxy'));
         app.kraken = config;
 
         // If options.mountpath was set, override config settings.

--- a/test/fixtures/settings/routes.js
+++ b/test/fixtures/settings/routes.js
@@ -2,5 +2,14 @@
 
 
 module.exports = function (router) {
-    // noop
+
+    router.get('/ip', function (req, res) {
+      var ip, err;
+
+      try {
+        ip = req.ip;
+      } catch (e) {}
+
+      res.send( ip ? 201 : 500);
+    });
 };


### PR DESCRIPTION
As a result of a change made in [express](/visionmedia/express/commit/566720) and [proxy-addr](expressjs/proxy-addr/commit/7a7a7e), our clobbering of app.settings was causing
a problem (`trust proxy fn` was never being set). This fix re-adds the `trust proxy` setting,
post-clobbering, to ensure express does what it needs to do.

We may want to change to iterating over our `express` config entries and `.set`ing them one-by-one
in the future, but this works for now.
