### PR TITLE
Move kraken to app.locals, where it should have been originally.

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -31,7 +31,14 @@ module.exports = function settings(app, options) {
         app.set('env', config.get('env:env'));
         app.set('view', config.get('express:view') ? require(config.get('express:view')) : View);
         app.set('trust proxy', config.get('express:trust proxy'));
-        app.kraken = config;
+
+        app.locals.kraken = config;
+        Object.defineProperty(app, 'kraken', {
+            get: function () {
+                return this.locals.kraken;
+            }
+        });
+
 
         // If options.mountpath was set, override config settings.
         app.settings.mountpath = (options.mountpath && options.mountpath !== '/') ? options.mountpath : app.settings.mountpath;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -39,7 +39,6 @@ module.exports = function settings(app, options) {
             }
         });
 
-
         // If options.mountpath was set, override config settings.
         app.settings.mountpath = (options.mountpath && options.mountpath !== '/') ? options.mountpath : app.settings.mountpath;
 


### PR DESCRIPTION
It was silly to add kraken directly to `app`. This is the first step in correcting that mistake. Later a warning can be put in the getter and after a time the `app.kraken` property can be completely removed.
