### PR TITLE
Default extended to true to preserve backward compat.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -77,7 +77,8 @@
             "priority": 70,
             "module": {
                 "name": "body-parser",
-                "method": "urlencoded"
+                "method": "urlencoded",
+                "arguments": [{ "extended": true }]
             }
         },
 


### PR DESCRIPTION
The `body-parser` module is [undergoing a change to make extended parsing disabled by default](https://github.com/expressjs/body-parser/issues/19) and as such is [displaying a warning message](https://github.com/expressjs/body-parser/blob/9b50957a62ea3acc6edca8dbd9d9f18e387ede93/lib/types/urlencoded.js#L41) indicating as such. This setting preserves existing functionality while suppressing the warning.

(NOTE: Until the version containing [this commit](https://github.com/expressjs/body-parser/commit/79743973743fa90c95945b4adab3dabcfc3cf989) is published, the warning will continue to appear.)

We should look to possibly default to `false` in the future.

``` bash
body-parser deprecated urlencoded: explicitly specify "extended: true" for extended parsing node_modules/kraken-js/node_modules/meddleware/index.js:98:20
```
