### PR TITLE
Explicitly set session defaults to suppress warning messages. Fixes #244

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -111,6 +111,8 @@
                             "httpOnly": true,
                             "maxAge": null
                         },
+                        "resave": true,
+                        "saveUninitialized": true,
                         "proxy": null
                     }
                 ]


### PR DESCRIPTION
`express-session` is going to be changing defaults for [`resave`](https://github.com/expressjs/session/commit/1b966ed4778acdacf57b1a4cc4ed23d9a709d058) and [`saveUninitialized`](https://github.com/expressjs/session/commit/c0363035410cdc5ba8f1a4c37aa28f600015919d), so explicilty setting current defaults to preserve backward compatibility (with a bonus side-effect of suppressing warnings per issue #244)
