### PR TITLE
removing morgan deprecation warnings

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -60,7 +60,10 @@
         "logger": {
             "enabled": true,
             "priority": 50,
-            "module": "morgan"
+            "module": {
+              "name": "morgan",
+              "arguments": [ "combined" ]
+            }
         },
 
         "json": {


### PR DESCRIPTION
morgan no longer has a default format. Explicitly setting `combined` to reflect expected behavior (as per [the commit](https://github.com/expressjs/morgan/commit/c11a384cb6757dc69c70365bfde3656b2ab919bd)).
