### PR TITLE
Update express dep to use ^ and set default version to known patched.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "shortstop": "0.0.1"
   },
   "peerDependencies": {
-    "express": "~3.4",
+    "express": "^3.15.0",
     "nconf": "~0.6"
   },
   "devDependencies": {
@@ -80,6 +80,6 @@
     "adaro": "~0.1.3",
     "makara": "~0.3.0",
     "supertest": "~0.8.1",
-    "express": "~3.4"
+    "express": "^3.15.0"
   }
 }

--- a/test/views.js
+++ b/test/views.js
@@ -244,8 +244,8 @@ describe('view', function () {
                 request(app)
                     .get('/')
                     .expect(500)
-                    .expect('Content-Type', /plain/)
-                    .expect(/^Error: No default engine was specified and no extension was provided/, next);
+                    .expect('Content-Type', /^text\/html/)
+                    .expect(/Error: No default engine was specified and no extension was provided/, next);
             }
         }
     };


### PR DESCRIPTION
To address the [qs security advisory](https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking) kraken@0.7 needs dependencies updated to include patched version. This will result in a 0.7.4 release.
