### PR TITLE
Fixes deprecation warnings regarding res.send

### DIFF
--- a/middleware/404.js
+++ b/middleware/404.js
@@ -24,7 +24,7 @@ module.exports = function (template) {
         var model = { url: req.url, statusCode: 404 };
         
         if (req.xhr) {
-            res.send(404, model);
+            res.status(404).send(model);
         } else {
             res.status(404);
             res.render(template, model);

--- a/middleware/500.js
+++ b/middleware/500.js
@@ -24,7 +24,7 @@ module.exports = function (template) {
         var model = { url: req.url, err: err, statusCode: 500 };
 
         if (req.xhr) {
-            res.send(500, model);
+            res.status(500).send(model);
         } else {
             res.status(500);
             res.render(template, model);


### PR DESCRIPTION
This cleans up the deprecation warnings from Express regarding `res.send(code, body)`. Switched to `res.status(code).send(body)`.
