### PR TITLE
'repository' still points to old github URL, hence old documentation on npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paypal/kraken-js.git"
+    "url": "https://github.com/krakenjs/kraken-js.git"
   },
   "author": "Erik Toth <ertoth@paypal.com>",
   "contributors": [


### PR DESCRIPTION
```
  "repository": {
    "type": "git",
    "url": "https://github.com/paypal/kraken-js.git"
  },
```

The URL value still points to paypal/kraken-js.git, while the newone is krakenjs/kraken-js.git
