### PR TITLE
Updating `package.json` to account for meddleware version update (2.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "express-session": "^1.0.3",
     "formidable": "^1.0.14",
     "lusca": "^1.0.0",
-    "meddleware": "^1.0.0",
+    "meddleware": "^2.0.0",
     "morgan": "^1.0.0",
     "serve-favicon": "^2.0.1",
     "serve-static": "^1.0.4",


### PR DESCRIPTION
Updating `package.json` to account for meddleware version update (now at 2.0.0)
- krakenjs/meddleware is now at version 2.0.0:
  https://github.com/krakenjs/meddleware/commit/01c2c8fbeade81eac8ea295ae30c5bcc1ed2d446
- One change that this version includes is the ability to always disable middleware from the config (via `"enabled": false`). Prior to this version, middleware that returned an instance of the express app would not be checked with regards to the `enabled` setting found in the `config.json`; thus the middleware would have had to handle this setting within the middleware logic itself. The latest change gives more control to the user of the middleware.
