### PR TITLE
Add better support for application composition.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -7,14 +7,6 @@
     "express": {
         "env": "", // NOTE: `env` is managed by the framework. This value will be overwritten.
         "x-powered-by": false,
-        "trust proxy": false,
-        "jsonp callback name": null,
-        "json replacer": null,
-        "json spaces": 0,
-        "case sensitive routing": false,
-        "strict routing": false,
-        "view cache": true,
-        "view engine": null,
         "views": "path:./views",
         "mountpath": "/"
     },

--- a/index.js
+++ b/index.js
@@ -38,10 +38,11 @@ module.exports = function (options) {
     }
 
     options = options || {};
-    options.protocols = options.protocols || {};
-    options.onconfig  = options.onconfig || noop;
-    options.basedir   = options.basedir || path.dirname(caller());
-    options.mountpath = null;
+    options.protocols    = options.protocols || {};
+    options.onconfig     = options.onconfig || noop;
+    options.basedir      = options.basedir || path.dirname(caller());
+    options.mountpath    = null;
+    options.inheritViews = !!options.inheritViews;
 
     debug('kraken options\n', options);
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -19,7 +19,6 @@
 
 var Bluebird = require('bluebird');
 var config = require('./config');
-var View = require('express/lib/view');
 var debug = require('debuglog')('kraken/settings');
 
 
@@ -60,6 +59,7 @@ module.exports = function settings(app, options) {
             delete app.settings[name];
         });
     }
+
 
     function compose(config) {
         // If this application is mounted on a parent app we need to make sure

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -26,15 +26,81 @@ var debug = require('debuglog')('kraken/settings');
 module.exports = function settings(app, options) {
     debug('initializing settings');
 
+    function mount(app, options, config) {
+        var settings, defaults, handler;
+
+        // Get configured settings and express defaults.
+        settings = config.get('express');
+        defaults = Object.keys(app.settings);
+
+        if (options.inheritViews) {
+            // If the mounted app SHOULD inherit views, delete from local
+            // kraken settings so the app settings aren't updated later.
+            handler = function (name) {
+                delete settings[name];
+            };
+        } else {
+            // If the views SHOULD NOT be inherited, remove from list
+            // of default settings such that they are NOT deleted delow.
+            handler = function (name) {
+                var idx = defaults.indexOf(name);
+                if (idx >= 0) {
+                    defaults.splice(idx, 1);
+                }
+            };
+        }
+
+        // Update our configuration (provided settings or app defaults)
+        ['views', 'view engine', 'view cache'].forEach(handler);
+
+        // Now delete the default app settings so they may be inherited
+        // from the parent app. Any remaining kraken config will be set
+        // during setting initialization.
+        defaults.forEach(function (name) {
+            delete app.settings[name];
+        });
+    }
+
+    function compose(config) {
+        // If this application is mounted on a parent app we need to make sure
+        // the two work together cleanly and appropriate settings are inherited.
+        if (typeof app.parent === 'function') {
+            // If it has already been mounted do all the work to update settings.
+            mount(app, options, config);
+        } else {
+            // ...if it hasn't been mounted, register a handler for the `mount`
+            // event to apply them as necessary.
+            app.once('mount', function () {
+                mount(this, options, config);
+            });
+        }
+
+        return config;
+    }
+
+
     function complete(config) {
-        app.settings = app.locals.settings = config.get('express');
-        app.set('env', config.get('env:env'));
-        app.set('view', config.get('express:view') ? require(config.get('express:view')) : View);
-        app.set('trust proxy', config.get('express:trust proxy'));
-        app.kraken = config;
+        var settings;
+
+        settings = config.get('express');
+
+        // Allow configuration of custom View impl. This really can be
+        // accomplished using shortstop, but maintain for compatibility.
+        if (typeof settings.view === 'string') {
+            settings.view = require(settings.view);
+        }
+
+        // Override default settings, leaving the settings object
+        // intact to maintain express' setting inheritance.
+        Object.keys(settings).forEach(function (name) {
+            app.set(name, settings[name]);
+        });
 
         // If options.mountpath was set, override config settings.
-        app.settings.mountpath = (options.mountpath && options.mountpath !== '/') ? options.mountpath : app.settings.mountpath;
+        app.set('mountpath', ((typeof options.mountpath === 'string') && options.mountpath !== '/') ? options.mountpath : app.get('mountpath'));
+        app.set('trust proxy', config.get('express:trust proxy'));
+        app.set('env', config.get('env:env'));
+        app.kraken = config;
 
         debug('express settings\n', app.settings);
         return app;
@@ -42,5 +108,6 @@ module.exports = function settings(app, options) {
 
     return config.create(options)
         .then(Bluebird.promisify(options.onconfig))
+        .then(compose)
         .then(complete);
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -22,6 +22,8 @@ var config = require('./config');
 var debug = require('debuglog')('kraken/settings');
 
 
+var VIEW_CONFIG_KEYS = ['views', 'view engine', 'view cache'];
+
 module.exports = function settings(app, options) {
     debug('initializing settings');
 
@@ -36,8 +38,10 @@ module.exports = function settings(app, options) {
             // If the mounted app SHOULD inherit views, delete from local
             // kraken settings so the app settings aren't updated later.
             handler = function (name) {
+                debug('inheriting express config setting', '\'' + name + '\'', 'from parent');
                 delete settings[name];
             };
+
         } else {
             // If the views SHOULD NOT be inherited, remove from list
             // of default settings such that they are NOT deleted below.
@@ -50,7 +54,7 @@ module.exports = function settings(app, options) {
         }
 
         // Update our configuration (provided settings or app defaults)
-        ['views', 'view engine', 'view cache'].forEach(handler);
+        VIEW_CONFIG_KEYS.forEach(handler);
 
         // Now delete the default app settings so they may be inherited
         // from the parent app. Any remaining kraken config will be set
@@ -95,6 +99,19 @@ module.exports = function settings(app, options) {
         Object.keys(settings).forEach(function (name) {
             app.set(name, settings[name]);
         });
+
+        if (options.inheritViews) {
+            // Update kraken config to reflect express settings
+            // for view options. Previously, the view settings
+            // were removed from config so only the appropriate
+            // settings were copied into express. At this point
+            // the app has been mounted and configures, so parent
+            // values are available to update kraken config as
+            // appropriate.
+            VIEW_CONFIG_KEYS.forEach(function (name) {
+                config.set('express:' + name, app.get(name));
+            });
+        }
 
         // If options.mountpath was set, override config settings.
         app.set('mountpath', ((typeof options.mountpath === 'string') && options.mountpath !== '/') ? options.mountpath : app.get('mountpath'));

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -40,7 +40,7 @@ module.exports = function settings(app, options) {
             };
         } else {
             // If the views SHOULD NOT be inherited, remove from list
-            // of default settings such that they are NOT deleted delow.
+            // of default settings such that they are NOT deleted below.
             handler = function (name) {
                 var idx = defaults.indexOf(name);
                 if (idx >= 0) {

--- a/test/composition.js
+++ b/test/composition.js
@@ -25,6 +25,7 @@ test('composition', function (t) {
 
                 // Compare settings to ensure they are inherited correctly.
                 t.notEqual(child.get('views'), parent.get('views'));
+                t.notEqual(child.kraken.get('express:views'), parent.kraken.get('express:views'));
                 SETTINGS.forEach(function (name) {
                     t.equal(child.get(name), parent.get(name), 'Expected \'' + name + '\' to be equal.');
                 });
@@ -72,6 +73,7 @@ test('composition', function (t) {
 
                 // Compare settings to ensure they are inherited correctly.
                 t.notEqual(child.get('views'), parent.get('views'));
+                t.notEqual(child.kraken.get('express:views'), parent.kraken.get('express:views'));
                 SETTINGS.forEach(function (name) {
                     t.equal(child.get(name), parent.get(name), 'Expected \'' + name + '\' to be equal.');
                 });
@@ -120,6 +122,7 @@ test('composition', function (t) {
 
                 // Compare settings to ensure they are inherited correctly.
                 t.equal(child.get('views'), parent.get('views'));
+                t.equal(child.kraken.get('express:views'), parent.kraken.get('express:views'));
                 SETTINGS.forEach(function (name) {
                     t.equal(child.get(name), parent.get(name), 'Expected \'' + name + '\' to be equal.');
                 });
@@ -181,6 +184,7 @@ test('composition', function (t) {
                 // Not checking all settings because child kraken app intentionally
                 // overrides some settings by default.
                 t.notEqual(this.get('views'), parent.get('views'));
+                t.notEqual(this.kraken.get('express:views'), parent.get('views'));
             }
         };
 

--- a/test/composition.js
+++ b/test/composition.js
@@ -1,0 +1,191 @@
+'use strict';
+
+process.env.NODE_ENV='_krakendev';
+
+var test = require('tape');
+var path = require('path');
+var express = require('express');
+var request = require('supertest');
+var kraken = require('../');
+
+
+test('composition', function (t) {
+
+    var SETTINGS = [ 'x-powered-by', 'etag', 'env', 'query parser', 'subdomain offset', 'trust proxy',
+                     'jsonp callback name', 'case sensitive routing', 'strict routing', 'query parser fn'];
+
+    t.test('plugin', function (t) {
+        var args, options, parent;
+
+        args = {
+            onstart: function onstart() {
+                var child;
+
+                child = this;
+
+                // Compare settings to ensure they are inherited correctly.
+                t.notEqual(child.get('views'), parent.get('views'));
+                SETTINGS.forEach(function (name) {
+                    t.equal(child.get(name), parent.get(name), 'Expected \'' + name + '\' to be equal.');
+                });
+
+                request(parent)
+                    .get('/')
+                    .expect(200)
+                    .expect('Hello, world!', function done(err) {
+                        t.error(err);
+                        t.end();
+                    });
+            },
+            onmount: Function.prototype
+        };
+
+        options = {
+            basedir: path.join(__dirname, 'fixtures', 'settings'),
+            onconfig: function (config, next) {
+                config.set('middleware:plugin', {
+                    enabled: true,
+                    priority: 119,
+                    module: {
+                        name: path.join(__dirname, 'fixtures', 'settings', 'lib', 'plugin'),
+                        arguments: [args]
+                    }
+                });
+                next(null, config);
+            }
+        };
+
+        parent = express();
+        parent.use(kraken(options));
+        parent.on('error', t.error.bind(t));
+    });
+
+
+    t.test('plugin with mountpath', function (t) {
+        var args, options, parent;
+
+        args = {
+            onstart: function onstart() {
+                var child;
+
+                child = this;
+
+                // Compare settings to ensure they are inherited correctly.
+                t.notEqual(child.get('views'), parent.get('views'));
+                SETTINGS.forEach(function (name) {
+                    t.equal(child.get(name), parent.get(name), 'Expected \'' + name + '\' to be equal.');
+                });
+
+                request(parent)
+                    .get('/plugin')
+                    .expect(200)
+                    .expect('Hello, world!', function done(err) {
+                        t.error(err);
+                        t.end();
+                    });
+            },
+            onmount: Function.prototype
+        };
+
+        options = {
+            basedir: path.join(__dirname, 'fixtures', 'settings'),
+            onconfig: function (config, next) {
+                config.set('middleware:plugin', {
+                    enabled: true,
+                    priority: 119,
+                    route: '/plugin',
+                    module: {
+                        name: path.join(__dirname, 'fixtures', 'settings', 'lib', 'plugin'),
+                        arguments: [args]
+                    }
+                });
+                next(null, config);
+            }
+        };
+
+        parent = express();
+        parent.use(kraken(options));
+        parent.on('error', t.error.bind(t));
+    });
+
+
+    t.test('inherited views', function (t) {
+        var args, options, parent;
+
+        args = {
+            onstart: function onstart() {
+                var child;
+
+                child = this;
+
+                // Compare settings to ensure they are inherited correctly.
+                t.equal(child.get('views'), parent.get('views'));
+                SETTINGS.forEach(function (name) {
+                    t.equal(child.get(name), parent.get(name), 'Expected \'' + name + '\' to be equal.');
+                });
+
+                request(parent)
+                    .get('/plugin')
+                    .expect(200)
+                    .expect('Hello, world!', function done(err) {
+                        t.error(err);
+                        t.end();
+                    });
+            },
+            onmount: Function.prototype,
+            inheritViews: true
+        };
+
+        options = {
+            basedir: path.join(__dirname, 'fixtures', 'settings'),
+            onconfig: function (config, next) {
+                config.set('middleware:plugin', {
+                    enabled: true,
+                    priority: 119,
+                    route: '/plugin',
+                    module: {
+                        name: path.join(__dirname, 'fixtures', 'settings', 'lib', 'plugin'),
+                        arguments: [args]
+                    }
+                });
+                next(null, config);
+            }
+        };
+
+        parent = express();
+        parent.use(kraken(options));
+        parent.on('error', t.error.bind(t));
+    });
+
+
+    t.test('late mounting', function () {
+        var args, factory, parent;
+
+        args = {
+            onstart: function onstart() {
+
+                // After the child has started, mount the application and make requests.
+                parent = express();
+                parent.use('/plugin', this);
+
+                request(parent)
+                    .get('/plugin')
+                    .expect(200)
+                    .expect('Hello, world!', function done(err) {
+                        t.error(err);
+                        t.end();
+                    });
+            },
+            onmount: function (parent) {
+                // Compare settings to ensure they are inherited correctly.
+                // Not checking all settings because child kraken app intentionally
+                // overrides some settings by default.
+                t.notEqual(this.get('views'), parent.get('views'));
+            }
+        };
+
+        factory = require('./fixtures/settings/lib/plugin');
+        factory(args);
+    });
+
+});

--- a/test/fixtures/settings/lib/plugin/index.js
+++ b/test/fixtures/settings/lib/plugin/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var express = require('express');
+var kraken = require('../../../../../');
+
+
+module.exports = function (options) {
+    var app;
+    app = express();
+    app.use(kraken({
+        inheritViews: options.inheritViews,
+        onconfig: function (config, next) {
+            // disable favicon to suppress config error caused my fixtures.
+            config.set('middleware:favicon', null);
+            next(null, config);
+        }
+    }));
+    app.on('mount', options.onmount);
+    app.on('start', options.onstart);
+    return app;
+};

--- a/test/fixtures/settings/lib/plugin/routes.js
+++ b/test/fixtures/settings/lib/plugin/routes.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (router) {
+
+    router.get('/', function (req, res) {
+        res.end('Hello, world!');
+    });
+
+};

--- a/test/settings.js
+++ b/test/settings.js
@@ -2,7 +2,6 @@
 
 process.env.NODE_ENV='_krakendev';
 
-var fs = require('fs');
 var test = require('tape');
 var path = require('path');
 var util = require('util');
@@ -69,14 +68,12 @@ test('settings', function (t) {
         var options, app;
 
         function start() {
-            var server;
-
-            function done(err) {
-                t.error(err);
-                t.end();
-            }
-
-            server = request(app).get('/ip').expect(201, done);
+            request(app)
+                .get('/ip')
+                .expect(201, function done(err) {
+                    t.error(err);
+                    t.end();
+                });
         }
 
         options = {


### PR DESCRIPTION
Merely `use`-ing express applications is practical, but doesn't quite go far enough in ensuring application settings are correctly inherited from the parent application. This PR:
- Allows express' built-in prototypical inheritance of settings to continue to be used.
- Changes how kraken handles express application configuration such that existing express settings are preserved and only specified settings are overridden. (Previously kraken replaces express settings.)
- Removes many redundant express setting overrides from default kraken config to allow express to add or remove settings without them having to be tracked here.  (Also allows express to continue to establish defaults).
- Add support for optionally inheriting view configuration (via `options.inheritViews`) from the parent app.
- Supports:
  - kraken apps to be mounted on kraken apps
  - non-kraken apps to be mounted on kraken apps
  - kraken apps to be mounted on non-kraken apps

NOTE: This change _should_ be backward compatible, and once merged to `v1.0.x` can be merged into master.
