### PR TITLE
Per Norm: session-redis -> redis-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ More complicated examples include configuring the session middleware to use a sh
           "session": {
               "module": {
                   // use our own module instead
-                  "name": "path:./lib/middleware/session-redis",
+                  "name": "path:./lib/middleware/redis-session",
                   "arguments": [
                       // express-session configuration
                       {


### PR DESCRIPTION
Changing a typo in the README as per Norm Ng (thanks Norm).
