### PR TITLE
Allow the app pass options to set custom headers for 503s while server is starting

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = function (options) {
         parent.use(function startup(req, res, next) {
             if (promise.isPending()) {
                 res.status(503);
-                var headers = options.startup && options.startup.headers;
+                var headers = options.startupHeaders;
                 if(headers){
                     Object.keys(headers).forEach(function(key){
                         res.header(key, headers[key]);

--- a/index.js
+++ b/index.js
@@ -71,6 +71,12 @@ module.exports = function (options) {
         parent.use(function startup(req, res, next) {
             if (promise.isPending()) {
                 res.status(503);
+                var headers = options.startup && options.startup.headers;
+                if(headers){
+                    Object.keys(headers).forEach(function(key){
+                        res.header(key, headers[key]);
+                    });
+                }
                 res.send('Server is starting.');
                 return;
             }

--- a/test/kraken.js
+++ b/test/kraken.js
@@ -217,11 +217,9 @@ test('kraken', function (t) {
             onconfig: function (settings, cb) {
                 setTimeout(cb.bind(null, null, settings), 1000);
             },
-            startup: {
-                headers: {
-                    "Custom-Header1": "Header1",
-                    "Custom-Header2": "Header2"
-                }
+            startupHeaders: {
+                "Custom-Header1": "Header1",
+                "Custom-Header2": "Header2"
             }
         };
 


### PR DESCRIPTION
During server startup we want to send some header while sending 503. This PR will enable the app to pass their custom headers.
