### PR TITLE
Replacing discouraged `deferred` with `new Promise`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -17,7 +17,7 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
-var Bluebird = require('bluebird');
+var Promise = require('bluebird');
 var path = require('path');
 var confit = require('confit');
 var handlers = require('shortstop-handlers');
@@ -50,9 +50,8 @@ function configPath(prefix) {
 
 
 exports.create = function create(options) {
-    var deferred, appProtocols, baseProtocols, baseFactory, appFactory;
+    var appProtocols, baseProtocols, baseFactory, appFactory;
 
-    deferred = Bluebird.pending();
     appProtocols = createHandlers(options);
     baseProtocols = createHandlers(options);
 
@@ -60,26 +59,28 @@ exports.create = function create(options) {
     baseProtocols.resolve = ssresolve(configPath(path.dirname(__dirname)));
 
     baseFactory = confit({ basedir: configPath(path.dirname(__dirname)), protocols: baseProtocols });
-    baseFactory.create(function(err, baseConf) {
-        if (err) {
-            deferred.reject(err);
-            return;
-        }
 
-        appFactory = confit({
-          basedir: configPath(options.basedir),
-          protocols: appProtocols
-        });
-        appFactory.create(function(err, appConf) {
+    return new Promise(function (resolve, reject) {
+        baseFactory.create(function (err, baseConf) {
             if (err) {
-                deferred.reject(err);
+                reject(err);
                 return;
             }
 
-            baseConf.merge(appConf);
-            deferred.resolve(baseConf);
+            appFactory = confit({
+              basedir: configPath(options.basedir),
+              protocols: appProtocols
+            });
+
+            appFactory.create(function (err, appConf) {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                baseConf.merge(appConf);
+                resolve(baseConf);
+            });
         });
     });
-
-    return deferred.promise;
 };


### PR DESCRIPTION
Quoting [Bluebird's documentation](https://github.com/petkaantonov/bluebird/blob/master/deprecated_apis.md#promise-resolution),

> **The use of `Promise.defer` and deferred objects is discouraged - it is much more awkward and error-prone than using `new Promise`**

Since [`pending()` is just an alias for `defer()`](https://github.com/petkaantonov/bluebird/blob/master/src/promise.js#L167), its usage is discouraged. The library author considers [`deferred` as an anti-pattern](https://github.com/petkaantonov/bluebird/wiki/Promise-anti-patterns#the-deferred-anti-pattern).

So, this PR replaces the `deferred` with `new Promise` way of creating a promise.

---

I actually considered using [`promisify`](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyfunction-nodefunction--dynamic-receiver---function), like this

```
return Bluebird.promisify(baseFactory.create)
    .call(baseFactory)
    .then(function (baseConf) {

        appFactory = confit({
          basedir: configPath(options.basedir),
          protocols: appProtocols
        });

        return Bluebird.promisify(appFactory.create)
            .call(appFactory)
            .then(function (appConf) {
                baseConf.merge(appConf);
                return baseConf;
            });
    });
```

Let me know which one is preferred.
