### PR TITLE
Add deprecation warning to 404/5xx middleware

### DIFF
--- a/middleware/404.js
+++ b/middleware/404.js
@@ -17,8 +17,10 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
+var deprecate = require('depd')('kraken-js/middleware/404');
 
-module.exports = function (template) {
+
+module.exports = deprecate.function(function fileNotFound(template) {
 
     return function fileNotFound(req, res, next) {
         var model = { url: req.url, statusCode: 404 };
@@ -31,4 +33,4 @@ module.exports = function (template) {
         }
     };
 
-};
+}, 'see github.com/krakenjs/kraken-js/issues/359');

--- a/middleware/500.js
+++ b/middleware/500.js
@@ -16,9 +16,12 @@
  │   limitations under the License.                                            │
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
-var debug = require('debuglog')('kraken/middleware/500');
 
-module.exports = function (template) {
+var deprecate = require('depd')('kraken-js/middleware/500');
+var debug = require('debuglog')('kraken-js/middleware/500');
+
+
+module.exports = deprecate.function(function serverError(template) {
 
     return function serverError(err, req, res, next) {
         debug('Server Error:', err.stack);
@@ -32,4 +35,4 @@ module.exports = function (template) {
         }
     };
     
-};
+}, 'see github.com/krakenjs/kraken-js/issues/359');

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "cookie-parser": "^1.0.1",
     "core-util-is": "^1.0.1",
     "debuglog": "~0.0.2",
+    "depd": "^1.0.1",
     "endgame": "^0.0.3",
     "express-enrouten": "^1.0.0",
     "express-session": "^1.0.3",


### PR DESCRIPTION
These middleware cause more problems than they solve.

Because they're everywhere, I'd like to keep them in place for another
major. The default express handler is sufficient in many cases. This is
more a documentation issue than anything else (and one we've already
addressed in the generator).

Closes #359.
