### PR TITLE
Bump `meddleware` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "express-session": "^1.0.3",
     "formidable": "^1.0.14",
     "lusca": "^1.0.0",
-    "meddleware": "^1.0.0",
+    "meddleware": "^3.0.0",
     "morgan": "^1.0.0",
     "serve-favicon": "^2.0.1",
     "serve-static": "^1.0.4",


### PR DESCRIPTION
So that it's consistent with `meddleware`'s documentation, especially that part about `enabled` being defaulted to `true`.
