### PR TITLE
Allow config path to be configurable

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -44,8 +44,9 @@ function createHandlers(options) {
     return result;
 }
 
-function configPath(prefix) {
-  return path.join(prefix, 'config');
+function configPath(prefix, configdir) {
+  configdir = (configdir) ? configdir : 'config';
+  return path.join(prefix, configdir);
 }
 
 
@@ -56,7 +57,7 @@ exports.create = function create(options) {
     appProtocols = createHandlers(options);
     baseProtocols = createHandlers(options);
 
-    appProtocols.resolve = ssresolve(configPath(options.basedir));
+    appProtocols.resolve = ssresolve(configPath(options.basedir, options.configdir));
     baseProtocols.resolve = ssresolve(configPath(path.dirname(__dirname)));
 
     baseFactory = confit({ basedir: configPath(path.dirname(__dirname)), protocols: baseProtocols });
@@ -67,7 +68,7 @@ exports.create = function create(options) {
         }
 
         appFactory = confit({
-          basedir: configPath(options.basedir),
+          basedir: configPath(options.basedir, options.configdir),
           protocols: appProtocols
         });
         appFactory.create(function(err, appConf) {

--- a/test/kraken.js
+++ b/test/kraken.js
@@ -70,6 +70,24 @@ test('kraken', function (t) {
         app.use(kraken({ basedir: __dirname }));
     });
 
+	t.test('startup with custom config directory', function (t) {
+		var app;
+
+        t.plan(1);
+
+        function start() {
+            t.pass('server started');
+        }
+
+        function error(err) {
+            t.error(err, 'server startup failed');
+        }
+
+        app = express();
+        app.on('start', start);
+        app.on('error', error);
+        app.use(kraken({ configdir: 'config' }));
+	});
 
     t.test('mount point', function (t) {
         var options, app, server;


### PR DESCRIPTION
Our current packaging system requires a directory called "config" in the root. Was easier to do this than change the packaging system. Figured I'd contribute the change + a test since it doesn't hurt anything. :smile:
