### PR TITLE
Partially fix domain memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "lusca": "^1.5.1",
     "meddleware": "^3.0.2",
     "morgan": "^1.5.2",
+    "on-finished": "^2.3.0",
     "serve-favicon": "^2.2.0",
     "serve-static": "^1.9.2",
     "shortstop": "^1.0.1",


### PR DESCRIPTION
After the response is finished, remove the request and
response objects from the domain and prevent them from
remaining in the captured scope of the domains error
listener.