### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"
+  - "node"
 script:
   - "npm run lint"
   - "npm run cover"


### PR DESCRIPTION
We should test on all current LTS branches. And remove Node.js 4 which already reached its EOL. See https://github.com/nodejs/Release/blob/master/README.md