### PR TITLE
Delay the listening till bootstrapping completes

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,12 +70,12 @@ module.exports = function (options) {
             const serverListen = parent.listen;
             parent.listen = function listenOverride() {
                 parent.on('start', () => {
-                    return serverListen.apply(parent, arguments)
-                })
+                    return serverListen.apply(parent, arguments);
+                });
              
                 parent.on('error', () => {
-                    return serverListen.apply(parent, arguments)
-                })
+                    return serverListen.apply(parent, arguments);
+                });
             };  
         }
 

--- a/index.js
+++ b/index.js
@@ -66,6 +66,18 @@ module.exports = function (options) {
         promise = bootstrap(parent, options);
         promise.then(start, error);
 
+        if (options.listenAfterBootstrap) {
+            const serverListen = parent.listen;
+            parent.listen = function listenOverride() {
+                parent.on('start', () => {
+                    return serverListen.apply(parent, arguments)
+                })
+             
+                parent.on('error', () => {
+                    return serverListen.apply(parent, arguments)
+                })
+            };  
+        }
 
         parent.use(function startup(req, res, next) {
             var headers = options.startupHeaders;


### PR DESCRIPTION
App starts taking the requests as soon as it starts listening irrespective of app is ready or not (i.e boot). 