### PR TITLE
Include process.cwd() while resolving module for view engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ npm-debug.log
 package-lock.json
 
 .project
+.vscode
 .idea
 .settings
 .iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - "12"
+  - "14"
+  - "16"
 script:
   - "npm run lint"
   - "npm run cover"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Include process.cwd while resolving module for view engine. It is possible that kraken-js module is deployed outside application root.
+
 # Release Notes
 
 kraken-js v2.3.0

--- a/lib/views.js
+++ b/lib/views.js
@@ -17,21 +17,48 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
+var path = require('path');
+var assert = require('assert');
 var thing = require('core-util-is');
 var debug = require('debuglog')('kraken/views');
+function tryResolverHelper(paths=module.paths) {
+    // If this module is deployed outside the app's node_modules, it wouldn't be
+    // able to resolve plugin modules deployed under app. Adding app's node_modules 
+    // folder to the paths will help handle this case.
+    const appDependencyPath = path.resolve(process.cwd(), 'node_modules');
+    if (!paths.includes(appDependencyPath)) {
+        paths = [ ...paths ];
+        paths.push(appDependencyPath);
+    }
+    return function tryResolve(modulePath) {
+        assert.strictEqual(typeof modulePath, 'string', 'modulePath should be a string');
+        try {
+            return require.resolve(modulePath, { paths });
+        } catch (e) {
+            if (e.code === 'MODULE_NOT_FOUND')
+                return;
+            throw e;
+        }
+    };
+}
 
 
 module.exports = function views(app) {
     var engines;
 
     debug('initializing views');
+    const tryResolve = tryResolverHelper();
 
     engines = app.kraken.get('view engines') || {};
     Object.keys(engines).forEach(function (ext) {
         var spec, module, args, engine;
 
         spec = engines[ext];
-        module = require(spec.module);
+        const modulePath = tryResolve(spec.module);
+        if (!modulePath) {
+          throw new TypeError(`Module ${spec.module} not found`);
+        }
+        module = require(modulePath);
 
         if (thing.isObject(spec.renderer) && thing.isFunction(module[spec.renderer.method])) {
             args = Array.isArray(spec.renderer['arguments']) ? spec.renderer['arguments'].slice() : [];

--- a/test/fixtures/views/.npmrc
+++ b/test/fixtures/views/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/test/fixtures/views/config/config.json
+++ b/test/fixtures/views/config/config.json
@@ -34,6 +34,13 @@
             "renderer": "renderFile"
         },
 
+        "txt": { 
+            "module": "test-text-renderer",
+            "renderer": {
+                "method": "txtHandler"
+            }
+        },
+
         "custom": {
             "module": "path:./lib/renderer",
             "name": "dust"

--- a/test/fixtures/views/package.json
+++ b/test/fixtures/views/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "view-engine",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "test-text-renderer": "file:view-engine/text"
+  }
+}

--- a/test/fixtures/views/view-engine/text/index.js
+++ b/test/fixtures/views/view-engine/text/index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const fs = require('fs');
+
+function txtHandler() {
+    return function renderer(file, options, cb) {
+        fs.readFile(file, function onread(err, html) {
+            if (err) {
+                cb(err);
+                return;
+            }
+            if (html && options) {
+                html = html.toString();
+                const supported_props = new Set([ 'name' ]);
+                for ( const [ name, value ] of Object.entries(options) ) {
+                    if (supported_props.has(name)) {
+                        html = html.replace(`%${name}%`, value);
+                    }
+                }
+                html = html.trim();
+            }
+            cb(null, html);
+        });
+    };
+}
+module.exports = {
+  txtHandler,
+  text: txtHandler(),
+};

--- a/test/fixtures/views/view-engine/text/package.json
+++ b/test/fixtures/views/view-engine/text/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-text-renderer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/views/views/index.txt
+++ b/test/fixtures/views/views/index.txt
@@ -1,0 +1,1 @@
+Hello, %name%! [Source: index.txt]


### PR DESCRIPTION
Include process.cwd() while resolving module for view engine. 

Before this change, if kraken-js was deployed outside the app's directory, it was not able to resolve view-engine modules deployed under app's node_modules directory.

Added unit test to test this case.
