### PR TITLE
Accept confit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ Handler for `uncaughtException` errors outside of the middleware chain. See the 
 
 For uncaught errors in the middleware chain, see `shutdown` middleware instead.
 
+#### `confit` (*Object*, optional)
+In rare cases, it may be useful to pass options directly to the confit module used within [lib/config.js](lib/config.js#71).
+For example, if [confit/shortstop is conflicting with environment variables](https://github.com/krakenjs/kraken-js/issues/470), you can explicitly ignore those environment variables:
+```javascript
+var options = {
+    confit: {
+        envignore: ['troublesome_environment_variable']
+    }
+};
+```
+
 ## Config Protocols
 kraken comes with the following shortstop protocol handlers by default:
 #### `import:`

--- a/lib/config.js
+++ b/lib/config.js
@@ -51,7 +51,7 @@ function configPath(prefix, configdir) {
 
 
 exports.create = function create(options) {
-    var deferred, appProtocols, baseProtocols, baseFactory, appFactory;
+    var deferred, appProtocols, baseProtocols, baseFactory, appFactory, baseConfig, appConfig;
 
     deferred = Bluebird.pending();
     appProtocols = createHandlers(options);
@@ -60,17 +60,29 @@ exports.create = function create(options) {
     appProtocols.resolve = ssresolve(configPath(options.basedir, options.configdir));
     baseProtocols.resolve = ssresolve(configPath(path.dirname(__dirname)));
 
-    baseFactory = confit({ basedir: configPath(path.dirname(__dirname)), protocols: baseProtocols });
+    baseConfig = Object.assign(
+        {
+            basedir: configPath(path.dirname(__dirname)),
+            protocols: baseProtocols
+        },
+        options.confit || {}
+    );
+
+    baseFactory = confit(baseConfig);
     baseFactory.create(function(err, baseConf) {
         if (err) {
             deferred.reject(err);
             return;
         }
 
-        appFactory = confit({
-          basedir: configPath(options.basedir, options.configdir),
-          protocols: appProtocols
-        });
+        appConfig = Object.assign(
+            {
+              basedir: configPath(options.basedir, options.configdir),
+              protocols: appProtocols
+            },
+            options.confit || {}
+        );
+        appFactory = confit(appConfig);
         appFactory.create(function(err, appConf) {
             if (err) {
                 deferred.reject(err);

--- a/test/settings.js
+++ b/test/settings.js
@@ -91,4 +91,24 @@ test('settings', function (t) {
 
     });
 
+    t.test('should accept confit options', function (t) {
+      var options, app, basedir;
+
+      process.env.krakenjs_test_settings_should_accept_confit_options = 'foo';
+
+      function onconfig(config, cb) {
+        var ignoredEnvVar = config.get('krakenjs_test_settings_should_accept_confit_options');
+        t.equal(ignoredEnvVar, undefined);
+        t.end();
+      }
+
+      app = express();
+      app.use(kraken({
+        basedir: path.join(__dirname, 'fixtures', 'settings'),
+        onconfig: onconfig,
+        confit: {
+            envignore: ['krakenjs_test_settings_should_accept_confit_options']
+        }
+      }));
+    });
 });


### PR DESCRIPTION
Options can now be passed directly to confit via `{ confit: {} }`. This can be used to mitigate issue #470.

@grawk LMK if this will work