### PR TITLE
Update formidable

### DIFF
--- a/lib/views.js
+++ b/lib/views.js
@@ -35,13 +35,13 @@ function tryResolverHelper(paths=module.paths) {
         try {
             return require.resolve(modulePath, { paths });
         } catch (e) {
-            if (e.code === 'MODULE_NOT_FOUND')
+            if (e.code === 'MODULE_NOT_FOUND') {
                 return;
+            }
             throw e;
         }
     };
 }
-
 
 module.exports = function views(app) {
     var engines;
@@ -51,6 +51,7 @@ module.exports = function views(app) {
 
     engines = app.kraken.get('view engines') || {};
     Object.keys(engines).forEach(function (ext) {
+        // jshint maxcomplexity:10
         var spec, module, args, engine;
 
         spec = engines[ext];

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "endgame": "^1.0.0",
     "express-enrouten": "^1.2.0",
     "express-session": "^1.10.4",
-    "formidable": "^1.0.17",
+    "formidable": "^3.5.4",
     "lusca": "^1.5.1",
     "meddleware": "^3.0.2",
     "morgan": "^1.5.2",

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -81,7 +81,7 @@ test('middleware', function (t) {
                 t.equal(typeof req.body, 'object');
                 t.equal(typeof req.files, 'object');
                 t.equal(typeof req.files.file, 'object');
-                t.equal(req.files.file.name, 'lazerz.jpg');
+                t.equal(req.files.file[0].originalFilename, 'lazerz.jpg');
                 res.status(200).end();
             });
 


### PR DESCRIPTION
This change is for CVE-2022-29622 remediation for the `formidable` package. Updating to latest should take care of it.

CI is failing because `formidable` requires Node 20 or later.

Given the two major version bumps, there were some breaking API changes. The full list can be found [here](https://github.com/node-formidable/formidable/blob/master/CHANGELOG.md), but the ones that seem to matter for this repo are:
- refactor: split file.name into file.newFilename and file.originalFilename (v2.0.0)
- files and fields values are always arrays (v3.0.0)
- feature: (https://github.com/node-formidable/formidable/pull/940) form.parse returns a promise if no callback is provided (v3.4.0)
  - it resolves with an array [fields, files]