### PR TITLE
Update formidable and other dependencies for security vulnerabilities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # unreleased
 
+## 2.6.0
+
+- Now requires Node v20 and later
+- Updated `formidable` dependency to `^3.5.4`
+  - Added compatibility layer to preserve current Kraken API
+- Updated several devDependencies
+
+## Release Notes
+
 kraken-js v2.5.0
 Released 2023-08-16
 

--- a/README.md
+++ b/README.md
@@ -473,8 +473,9 @@ kraken-js looks to the `view engines` config property to understand how to load 
 ```js
 {
     "view engines": {
-        "jade": {
-            "module": "consolidate"
+        "pug": {
+            "module": "pug",
+            "renderer": "renderFile"
         },
         "html": {
             "name": "ejs",

--- a/config/config.json
+++ b/config/config.json
@@ -44,7 +44,8 @@
             "enabled": true,
             "priority": 40,
             "module": {
-                "name": "serve-static",
+                "name": "express",
+                "method": "static",
                 "arguments": [ "path:./public" ]
             }
         },
@@ -67,7 +68,7 @@
             "enabled": true,
             "priority": 60,
             "module": {
-                "name": "body-parser",
+                "name": "express",
                 "method": "json"
             }
         },
@@ -76,7 +77,7 @@
             "enabled": true,
             "priority": 70,
             "module": {
-                "name": "body-parser",
+                "name": "express",
                 "method": "urlencoded",
                 "arguments": [{ "extended": true }]
             }

--- a/lib/views.js
+++ b/lib/views.js
@@ -35,8 +35,9 @@ function tryResolverHelper(paths=module.paths) {
         try {
             return require.resolve(modulePath, { paths });
         } catch (e) {
-            if (e.code === 'MODULE_NOT_FOUND')
+            if (e.code === 'MODULE_NOT_FOUND') {
                 return;
+            }
             throw e;
         }
     };
@@ -50,6 +51,7 @@ module.exports = function views(app) {
     const tryResolve = tryResolverHelper();
 
     engines = app.kraken.get('view engines') || {};
+    // jshint maxcomplexity: 10
     Object.keys(engines).forEach(function (ext) {
         var spec, module, args, engine;
 

--- a/middleware/multipart.js
+++ b/middleware/multipart.js
@@ -18,8 +18,10 @@
 'use strict';
 
 var fs = require('fs'),
-    IncomingForm = require('formidable').IncomingForm,
+    formidable = require('formidable'),
+    { firstValues } = require('formidable/src/helpers/firstValues.js'),
     debug = require('debuglog')('kraken/middleware/multipart');
+var IncomingForm = formidable.IncomingForm;
 
 
 /**
@@ -67,8 +69,10 @@ function cleanify(files) {
  * @param file a formidable File object
  */
 function funlink(file) {
-    var path = file.path;
-    debug('removing', file.name);
+    // Handle both formidable 1.x and 3.x file object properties
+    var path = file.filepath || file.path; // 3.x uses filepath, 1.x uses path
+    var name = file.originalFilename || file.name; // 3.x uses originalFilename, 1.x uses name
+    debug('removing', name);
     if (typeof path === 'string') {
         fs.unlink(path, function (err) {
             if (err) {
@@ -91,10 +95,37 @@ module.exports = function (config) {
                 return;
             }
 
-            req.body = fields;
-            req.files = files;
-            res.once('finish', cleanify(files));
+            // Use firstValues to handle formidable 3.x array format
+            req.body = firstValues(form, fields);
+            req.files = addBackwardCompatibility(firstValues(form, files));
+            res.once('finish', cleanify(req.files));
             next();
         });
     });
 };
+
+
+/**
+ * Add backward compatibility properties to file objects
+ * @param files the files object from formidable
+ */
+function addBackwardCompatibility(files) {
+    if (!files) {
+        return {};
+    }
+    
+    Object.keys(files).forEach(function(key) {
+        var file = files[key];
+        if (file) {
+            // Add backward compatibility properties for both formidable versions
+            file.path = file.filepath || file.path;
+            file.name = file.originalFilename || file.name;
+            file.type = file.mimetype || file.type;
+            // Also add forward compatibility
+            file.filepath = file.filepath || file.path;
+            file.originalFilename = file.originalFilename || file.name;
+            file.mimetype = file.mimetype || file.type;
+        }
+    });
+    return files;
+}

--- a/middleware/multipart.js
+++ b/middleware/multipart.js
@@ -70,8 +70,8 @@ function cleanify(files) {
  */
 function funlink(file) {
     // Handle both formidable 1.x and 3.x file object properties
-    var path = file.filepath || file.path; // 3.x uses filepath, 1.x uses path
-    var name = file.originalFilename || file.name; // 3.x uses originalFilename, 1.x uses name
+    var path = file.filepath ?? file.path; // 3.x uses filepath, 1.x uses path
+    var name = file.originalFilename ?? file.name; // 3.x uses originalFilename, 1.x uses name
     debug('removing', name);
     if (typeof path === 'string') {
         fs.unlink(path, function (err) {
@@ -118,13 +118,9 @@ function addBackwardCompatibility(files) {
         var file = files[key];
         if (file) {
             // Add backward compatibility properties for both formidable versions
-            file.path = file.filepath || file.path;
-            file.name = file.originalFilename || file.name;
-            file.type = file.mimetype || file.type;
-            // Also add forward compatibility
-            file.filepath = file.filepath || file.path;
-            file.originalFilename = file.originalFilename || file.name;
-            file.mimetype = file.mimetype || file.type;
+            file.path ??= file.filepath;
+            file.name ??= file.originalFilename;
+            file.type ??= file.mimetype;
         }
     });
     return files;

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "body-parser": "^2.2.0",
     "caller": "^1.0.0",
     "compression": "^1.4.3",
     "confit": "^3.0.0",
@@ -90,7 +89,6 @@
     "meddleware": "^3.0.2",
     "morgan": "^1.5.2",
     "serve-favicon": "^2.2.0",
-    "serve-static": "^2.2.0",
     "shortstop": "^1.0.1",
     "shortstop-handlers": "^1.0.0",
     "shortstop-resolve": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,11 +56,11 @@
     }
   ],
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "devDependencies": {
     "consolidate": "^1.0.4",
-    "dustjs-linkedin": "^3.0.1",
+    "dustjs-linkedin": "^2.7.5",
     "ejs": "^3.1.10",
     "express": "^4.8.4",
     "istanbul": "^0.4.5",
@@ -85,7 +85,7 @@
     "endgame": "^1.0.0",
     "express-enrouten": "^1.2.0",
     "express-session": "^1.10.4",
-    "formidable": "^1.0.17",
+    "formidable": "^3.5.4",
     "lusca": "^1.5.1",
     "meddleware": "^3.0.2",
     "morgan": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -59,13 +59,13 @@
     "node": ">= 20"
   },
   "devDependencies": {
-    "consolidate": "^1.0.4",
-    "dustjs-linkedin": "^2.7.5",
+    "consolidate": "^0.16.0",
+    "dustjs-linkedin": "^3.0.1",
     "ejs": "^3.1.10",
     "express": "^4.8.4",
     "istanbul": "^0.4.5",
-    "jade": "^1.9.2",
     "jshint": "^2.6.3",
+    "pug": "^3.0.3",
     "supertest": "^7.1.4",
     "tape": "^5.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -56,25 +56,25 @@
     }
   ],
   "engines": {
-    "node": ">= 4"
+    "node": ">= 18"
   },
   "devDependencies": {
-    "consolidate": "^0.15.1",
-    "dustjs-linkedin": "^2.6.2",
-    "ejs": "^2.3.1",
+    "consolidate": "^1.0.4",
+    "dustjs-linkedin": "^3.0.1",
+    "ejs": "^3.1.10",
     "express": "^4.8.4",
     "istanbul": "^0.4.5",
     "jade": "^1.9.2",
     "jshint": "^2.6.3",
-    "supertest": "^4.0.2",
-    "tape": "^4.0.0"
+    "supertest": "^7.1.4",
+    "tape": "^5.9.0"
   },
   "peerDependencies": {
     "express": "^4.8.4"
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "body-parser": "^1.12.2",
+    "body-parser": "^2.2.0",
     "caller": "^1.0.0",
     "compression": "^1.4.3",
     "confit": "^3.0.0",
@@ -90,7 +90,7 @@
     "meddleware": "^3.0.2",
     "morgan": "^1.5.2",
     "serve-favicon": "^2.2.0",
-    "serve-static": "^1.9.2",
+    "serve-static": "^2.2.0",
     "shortstop": "^1.0.1",
     "shortstop-handlers": "^1.0.0",
     "shortstop-resolve": "^1.0.1",

--- a/test/fixtures/views/config/config.json
+++ b/test/fixtures/views/config/config.json
@@ -29,8 +29,8 @@
             }
         },
 
-        "jade": {
-            "module": "jade",
+        "pug": {
+            "module": "pug",
             "renderer": "renderFile"
         },
 

--- a/test/views.js
+++ b/test/views.js
@@ -89,7 +89,7 @@ test('views', function (t) {
         options = {
             basedir,
             onconfig: function (settings, cb) {
-                settings.set('express:view engine', 'jade');
+                settings.set('express:view engine', 'pug');
                 cb(null, settings);
             }
         };


### PR DESCRIPTION
This change is for CVE-2022-29622 remediation for the `formidable` package. Also updating other dependencies to mitigate other vulnerabilities.

Given the two major version bumps, there were some breaking API changes. The full list can be found [here](https://github.com/node-formidable/formidable/blob/master/CHANGELOG.md), but the ones that matter for this repo are:
- refactor: split file.name into file.newFilename and file.originalFilename (v2.0.0)
- files and fields values are always arrays (v3.0.0)
- feature: (https://github.com/node-formidable/formidable/pull/940) form.parse returns a promise if no callback is provided (v3.4.0)
  - it resolves with an array [fields, files]